### PR TITLE
Adds `gemini-node-sse` to the main README demos list

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,4 @@ This repository contains demos related to the AI on-device talk for Google I/O 2
 ## List of demos
 
 - `product-reviews`: a demo with on-device sentiment analysis, toxicity, and rating assesment of a product review.
+- `gemini-node-sse`: This demo shows how to use Server Sent Events (SSE) to stream content from Gemini, using Node.js and the Google AI SDK for JavaScript to a web application.


### PR DESCRIPTION
Adds `gemini-node-sse` to the main README demos list