### PR TITLE
Improve type definitions for the Prompt API

### DIFF
--- a/weather-ai/src/lib/prompting/index.ts
+++ b/weather-ai/src/lib/prompting/index.ts
@@ -3,20 +3,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { ReadableStream } from "stream/web";
 
 export default class BuiltinPrompting {
-    constructor(private session: any) {}
+    constructor(private session: AITextSession) {}
 
-
-    streamingPrompt(prompt: string): any {
-        // Prompt the model and stream the result:
-        const stream = this.session.promptStreaming(prompt);
-        const reader = stream.getReader();
-        return reader;
+    async streamingPrompt(prompt: string): Promise<ReadableStream<string>> {
+        return await this.session.promptStreaming(prompt);
     }
     
     async prompt(prompt: string): Promise<string> {
-        return await this.session.execute(prompt);        
+        return await this.session.prompt(prompt);
     }
 
     static async createPrompting(): Promise<BuiltinPrompting> {

--- a/weather-ai/src/types.d.ts
+++ b/weather-ai/src/types.d.ts
@@ -3,10 +3,30 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { ReadableStream } from "stream/web";
+
 export {};
 
 declare global {
+  type AIModelAvailability = 'readily' |  'after-download' | 'no';
+  type AITextSessionOptions = {
+    temperature: number,
+    topK: number,
+  }
+
+  type AITextSession = {
+    promptStreaming: (string) => Promise<ReadableStream<string>>,
+    prompt: (string) => Promise<string>,
+    destroy: () => void;
+    clone: () => AITextSession;
+  }
+
   interface Window {
-    ai: any;
+    ai: {
+      defaultTextSessionOptions: () => Promise<AITextSessionOptions>,
+      canCreateTextSession: () => Promise<AIModelAvailability>,
+      createTextSession: (options?: AITextSessionOptions) => Promise<AITextSession>,
+      createGenericSession: (options: AITextSessionOptions) => Promise<AITextSession>,
+    };
   }
 }


### PR DESCRIPTION
- The window.ai API types were definited as `any`, not taking advantage of Typescript types.
- This PR updates `types.d.ts` to define types proper, then updates code to use them, making the code more idiomatic.