### PR TITLE
Remove unecessary await from weather demo

### DIFF
--- a/weather-ai/src/lib/prompting/index.ts
+++ b/weather-ai/src/lib/prompting/index.ts
@@ -9,11 +9,11 @@ export default class BuiltinPrompting {
     constructor(private session: AITextSession) {}
 
     async streamingPrompt(prompt: string): Promise<ReadableStream<string>> {
-        return await this.session.promptStreaming(prompt);
+        return this.session.promptStreaming(prompt);
     }
     
     async prompt(prompt: string): Promise<string> {
-        return await this.session.prompt(prompt);
+        return this.session.prompt(prompt);
     }
 
     static async createPrompting(): Promise<BuiltinPrompting> {

--- a/weather-ai/src/lib/prompting/index.ts
+++ b/weather-ai/src/lib/prompting/index.ts
@@ -8,11 +8,11 @@ import { ReadableStream } from "stream/web";
 export default class BuiltinPrompting {
     constructor(private session: AITextSession) {}
 
-    async streamingPrompt(prompt: string): Promise<ReadableStream<string>> {
+    streamingPrompt(prompt: string): Promise<ReadableStream<string>> {
         return this.session.promptStreaming(prompt);
     }
     
-    async prompt(prompt: string): Promise<string> {
+    prompt(prompt: string): Promise<string> {
         return this.session.prompt(prompt);
     }
 


### PR DESCRIPTION
The method returns a promise, so it is not necessary to await when calling the Propt APIs.