### PR TITLE
Don't await on page load for sentiment analysis

### DIFF
--- a/product-reviews/src/app.jsx
+++ b/product-reviews/src/app.jsx
@@ -37,7 +37,7 @@ import SupportChatWindow from './components/supportchat/SupportChatWindow';
 env.allowLocalModels = false;
 env.useBrowserCache = false;
 // Allocate a pipeline for sentiment-analysis
-let transformersjsClassifierSentiment = pipeline('sentiment-analysis');
+let transformersjsClassifierSentimentPromise = pipeline('sentiment-analysis');
 
 const toxicWarning =
   'Your comment may be toxic. Please rephrase it before posting. We would like to share your feedback with other users! ';
@@ -145,6 +145,7 @@ export function App() {
     setSentiment(UNKNOWN);
 
     // POSITIVE NEGATIVE CLASSIFIER (ON-DEVICE)
+    const transformersjsClassifierSentiment = await transformersjsClassifierSentimentPromise;
     const sentimentResult = await transformersjsClassifierSentiment(review);
     console.log(sentimentResult);
     const sentiment = sentimentResult[0].label;

--- a/product-reviews/src/app.jsx
+++ b/product-reviews/src/app.jsx
@@ -37,7 +37,7 @@ import SupportChatWindow from './components/supportchat/SupportChatWindow';
 env.allowLocalModels = false;
 env.useBrowserCache = false;
 // Allocate a pipeline for sentiment-analysis
-let transformersjsClassifierSentiment = await pipeline('sentiment-analysis');
+let transformersjsClassifierSentiment = pipeline('sentiment-analysis');
 
 const toxicWarning =
   'Your comment may be toxic. Please rephrase it before posting. We would like to share your feedback with other users! ';


### PR DESCRIPTION
By not awaiting for the sentiment analysis pipeline to be fully loaded before displaying any content on page load, we **improve the LCP score from 3.10s to 0.75s** - a 75.81% improvement on a 470Mbps high-speed internet connection.
 
This should hopefully be a best practice in documentation like https://web.dev/articles/llm-sizes.

_Before_:<img width="1840" alt="Screenshot 2024-07-02 at 10 53 22" src="https://github.com/GoogleChromeLabs/web-ai-demos/assets/634478/7701f86f-3b40-4d83-a857-d576d7a6d9ce">
_After_:<img width="1840" alt="Screenshot 2024-07-02 at 10 53 13" src="https://github.com/GoogleChromeLabs/web-ai-demos/assets/634478/7d129e8b-90da-483a-b6a8-e9eb0afdbdc3">

@maudnals Please review
