### PR TITLE
Remove `createGenericSession` from types.d.ts

### DIFF
--- a/weather-ai/src/types.d.ts
+++ b/weather-ai/src/types.d.ts
@@ -26,7 +26,6 @@ declare global {
       defaultTextSessionOptions: () => Promise<AITextSessionOptions>,
       canCreateTextSession: () => Promise<AIModelAvailability>,
       createTextSession: (options?: AITextSessionOptions) => Promise<AITextSession>,
-      createGenericSession: (options: AITextSessionOptions) => Promise<AITextSession>,
     };
   }
 }


### PR DESCRIPTION
`createGenericSession()` is deprecated and won't be part of the final API. It's not currently used in the demo.