### PR TITLE
Add warning when summarization content exceeds 4000 chars

### DIFF
--- a/summarization-api-playground/index.html
+++ b/summarization-api-playground/index.html
@@ -19,7 +19,7 @@
         <div>
           <h2>Input</h2>
           <textarea id="input"></textarea>
-          <div><span id="character-count">0</span></div>
+          <div>Character Count: <span id="character-count">0</span><span id="character-count-exceed" class="hidden"> (may exceed maximum token limit supported by the API.)</span></div>
         </div>
         <div>
           <h2>Summary</h2>

--- a/summarization-api-playground/src/main.ts
+++ b/summarization-api-playground/src/main.ts
@@ -5,8 +5,13 @@
 
 import './style.css'
 
+// The underlying model has a context of 1024 tokens, of which 26 are used by the internal prompt,
+// leaving about 998 tokens for the input text. Each token is, roughly, about 4 characters, so 4000
+// is used as a limit to warn the user the content might be too long to summarize.
+const MAX_MODEL_CHARS = 4000;
 const inputTextArea = document.querySelector('#input') as HTMLTextAreaElement;
 const characterCountSpan = document.querySelector('#character-count') as HTMLSpanElement;
+const characterCountExceededSpan = document.querySelector('#character-count-exceed') as HTMLSpanElement;
 const summarizationUnsupportedDialog = document.querySelector('#summarization-unsupported') as HTMLDialogElement;
 const summarizationUnavailableDialog = document.querySelector('#summarization-unavailable') as HTMLDialogElement;
 const output = document.querySelector('#output') as HTMLDivElement;
@@ -61,6 +66,13 @@ const initializeApplication = async () => {
   let timeout: number | undefined = undefined;
   inputTextArea.addEventListener('input', () => {
     characterCountSpan.textContent = inputTextArea.value.length.toFixed();
+    if (inputTextArea.value.length > MAX_MODEL_CHARS) {
+      characterCountSpan.classList.add('tokens-exceeded');
+      characterCountExceededSpan.classList.remove('hidden');
+    } else {
+      characterCountSpan.classList.remove('tokens-exceeded');
+      characterCountExceededSpan.classList.add('hidden');
+    }
 
     // Debounces the call to the summarization API. This will run the summarization once the user
     // hasn't typed anything for at least 1 second.

--- a/summarization-api-playground/src/main.ts
+++ b/summarization-api-playground/src/main.ts
@@ -6,7 +6,7 @@
 import './style.css'
 
 // The underlying model has a context of 1,024 tokens, out of which 26 are used by the internal prompt,
-// leaving about 998 tokens for the input text. Each token is, roughly, about 4 characters, so 4000
+// leaving about 998 tokens for the input text. Each token corresponds, roughly, to about 4 characters, so 4,000
 // is used as a limit to warn the user the content might be too long to summarize.
 const MAX_MODEL_CHARS = 4000;
 const inputTextArea = document.querySelector('#input') as HTMLTextAreaElement;

--- a/summarization-api-playground/src/main.ts
+++ b/summarization-api-playground/src/main.ts
@@ -5,7 +5,7 @@
 
 import './style.css'
 
-// The underlying model has a context of 1024 tokens, of which 26 are used by the internal prompt,
+// The underlying model has a context of 1,024 tokens, out of which 26 are used by the internal prompt,
 // leaving about 998 tokens for the input text. Each token is, roughly, about 4 characters, so 4000
 // is used as a limit to warn the user the content might be too long to summarize.
 const MAX_MODEL_CHARS = 4000;

--- a/summarization-api-playground/src/style.css
+++ b/summarization-api-playground/src/style.css
@@ -21,6 +21,13 @@ html {
   box-sizing: border-box;
 }
 
+header, main, footer {
+  width: 100%;
+  max-width: 1000px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
 *, *:before, *:after {
   box-sizing: inherit;
 }
@@ -50,7 +57,6 @@ main {
 
 footer {
   background-color: darkgreen;
-  margin: 0;
   padding: 8px;
   border-radius: 4px;
 }
@@ -69,6 +75,14 @@ dialog {
   background-color: darkred;
   border: 1px solid red;
   border-radius: 4px;
+}
+
+.tokens-exceeded, #character-count-exceed {
+  color: red;
+}
+
+.hidden {
+  display: none;
 }
 
 @media (prefers-color-scheme: light) {


### PR DESCRIPTION
- The API currently supports a maximum of 998 token. Each token is roughly 4 characters, meaning the API will support around 4000 characters.
- So, we add a warning when the user input exceeds 4000 characters.
- This API also adjusts the maximum width of the layout.