### PR TITLE
Add summary settings to Summarization Playground

### DIFF
--- a/summarization-api-playground/index.html
+++ b/summarization-api-playground/index.html
@@ -16,14 +16,41 @@
       <h1>Summarization API Playground</h1>
     </header>
     <main>
-        <div>
-          <h2>Input</h2>
+        <fieldset>
+          <legend>Prompt</legend>
           <textarea id="input"></textarea>
           <div>Character Count: <span id="character-count">0</span><span id="character-count-exceed" class="hidden"> (may exceed maximum token limit supported by the API.)</span></div>
-        </div>
+        </fieldset>
+        <fieldset>
+          <legend>Settings</legend>
+          <div>
+            <label for="type">Summary Type:</label>
+            <select id="type">
+              <option value="key-points" selected>Key Points</option>
+              <option value="tl;dr">TL;DR</option>
+              <option value="teaser">Teaser</option>
+              <option value="headline">Headline</option>
+            </select>            
+          </div>
+          <div>
+            <label for="length">Length:</label>
+            <select id="length">
+              <option value="short" selected>Short</option>
+              <option value="medium">Medium</option>
+              <option value="long">Long</option>
+            </select>
+          </div>
+          <div>
+            <label for="format">Format:</label>
+            <select id="format">
+              <option value="markdown" selected>Markdown</option>
+              <option value="plain-text">Plain text</option>
+            </select>
+          </div>
+        </fieldset>
         <div>
           <h2>Summary</h2>
-          <div id="output"></div>
+          <pre id="output"></pre>
         </div>
     </main>
     <footer>

--- a/summarization-api-playground/package-lock.json
+++ b/summarization-api-playground/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "summarization-api-playground",
       "version": "0.0.0",
+      "license": "Apache-2.0",
       "devDependencies": {
         "typescript": "^5.2.2",
         "vite": "^5.3.4"

--- a/summarization-api-playground/src/main.ts
+++ b/summarization-api-playground/src/main.ts
@@ -41,7 +41,7 @@ const createSummarizationSession = async (
     throw new Error('AI Summarization is not supported');
   }
 
-  const summarizationSession = await window.ai.summarizer!.create({type: type, format: format, length: length});
+  const summarizationSession = await window.ai.summarizer!.create({type, format, length});
   if (canSummarize.available === 'after-download') {
     if (downloadProgressCallback) {
       summarizationSession.addEventListener('downloadprogress', downloadProgressCallback);

--- a/summarization-api-playground/src/style.css
+++ b/summarization-api-playground/src/style.css
@@ -77,6 +77,10 @@ dialog {
   border-radius: 4px;
 }
 
+pre {
+  text-wrap: auto;
+}
+
 .tokens-exceeded, #character-count-exceed {
   color: red;
 }

--- a/summarization-api-playground/src/types.d.ts
+++ b/summarization-api-playground/src/types.d.ts
@@ -7,9 +7,19 @@ export {};
 
 declare global {
   type AIModelAvailability = 'readily' |  'after-download' | 'no';
+  type AISummarizerType = 'tl;dr' | 'key-points' | 'teaser' | 'headline';
+  type AISummarizerFormat = 'plain-text' | 'markdown';
+  type AISummarizerLength = 'short' | 'medium' | 'long' ;
+
+  type AISummarizerCreateOptions = {
+    type?: AISummarizerType,
+    length?: AISummarizerLength,
+    format?: AISummarizerFormat,
+  };
+
   type AISummarizer = {
     capabilities: () => Promise<AISummarizerCapabilities>;
-    create: () => Promise<AISummarizerSession>;
+    create: (options?: AISummarizerCreateOptions) => Promise<AISummarizerSession>;
   }
 
   type AISummarizerCapabilities = {


### PR DESCRIPTION
- Recent implementations of the API allow setting the type, length and format of the summarizer.
- This PR introduces a fieldset on the page that allows the user to change the settings for the output summary, and code that supports this behaviour.
- This is a screenshot of the UI
![localhost_5173_ (1)](https://github.com/user-attachments/assets/3a00721c-c8fe-49ed-937d-7d9bd95f1965)
