### PR TITLE
Demo fixes for the Origin Trial

### DIFF
--- a/summarization-api-playground/index.html
+++ b/summarization-api-playground/index.html
@@ -30,7 +30,7 @@
               <option value="tl;dr">TL;DR</option>
               <option value="teaser">Teaser</option>
               <option value="headline">Headline</option>
-            </select>            
+            </select>
           </div>
           <div>
             <label for="length">Length:</label>
@@ -56,11 +56,11 @@
     <footer>
       Be the first to test new AI APIs. Your feedback is invaluable to our development process. Join our <a href=" https://developer.chrome.com/docs/ai/built-in#get_an_early_preview">Early Preview Program</a> today.
     </footer>
-    <dialog id="summarization-unavailable">
+    <div class="dialog" id="summarization-unavailable">
       <div>Your browser doesn't support the Summarization API. If you're on Chrome, join the <a href=" https://developer.chrome.com/docs/ai/built-in#get_an_early_preview">Early Preview Program</a> and enable it.</div>
-    </dialog>
-    <dialog id="summarization-unsupported">
+    </div>
+    <div class="dialog" id="summarization-unsupported">
       <div>The Summarization API is available, but your device is unable to run it. Check device requirements in the <a href=" https://developer.chrome.com/docs/ai/built-in#get_an_early_preview">Early Preview Program</a> documentation.</div>
-    </dialog>
+    </div>
   </body>
 </html>

--- a/summarization-api-playground/index.html
+++ b/summarization-api-playground/index.html
@@ -6,6 +6,10 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
+
+    <!-- Summarizer API --->
+    <meta http-equiv="origin-trial" content="Aiqz8ZArzAhQ2U24U9mLLJV8l16YNGsuiDqHJcUD3eCqYDbrWpb8qG3BSMXJ4OxDyS6Zw9HlsS5/ZoD0AFDAUQEAAABWeyJvcmlnaW4iOiJodHRwczovL2Nocm9tZS5kZXY6NDQzIiwiZmVhdHVyZSI6IkFJU3VtbWFyaXphdGlvbkFQSSIsImV4cGlyeSI6MTc1MzE0MjQwMH0=" />
+
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <script type="module" src="./src/main.ts"></script>

--- a/summarization-api-playground/src/main.ts
+++ b/summarization-api-playground/src/main.ts
@@ -15,18 +15,18 @@ const summaryFormatSelect = document.querySelector('#format') as HTMLSelectEleme
 const summaryLengthSelect = document.querySelector('#length') as HTMLSelectElement;
 const characterCountSpan = document.querySelector('#character-count') as HTMLSpanElement;
 const characterCountExceededSpan = document.querySelector('#character-count-exceed') as HTMLSpanElement;
-const summarizationUnsupportedDialog = document.querySelector('#summarization-unsupported') as HTMLDialogElement;
-const summarizationUnavailableDialog = document.querySelector('#summarization-unavailable') as HTMLDialogElement;
+const summarizationUnsupportedDialog = document.querySelector('#summarization-unsupported') as HTMLDivElement;
+const summarizationUnavailableDialog = document.querySelector('#summarization-unavailable') as HTMLDivElement;
 const output = document.querySelector('#output') as HTMLDivElement;
 
 /*
  * Creates a summarization session. If the model has already been downloaded, this function will
  * create the session and return it. If the model needs to be downloaded, this function will
  * wait for the download to finish before resolving the promise.
- * 
+ *
  * If a downloadProgressCallback is provided, the function will add the callback to the session
  * creation.
- * 
+ *
  * The function expects the model availability to be either `readily` or `after-download`, so the
  * availability must be checked before calling it. If availability is `no`, the function will throw
  *  an error.
@@ -60,13 +60,13 @@ const createSummarizationSession = async (
 const initializeApplication = async () => {
   const summarizationApiAvailable = window.ai !== undefined && window.ai.summarizer !== undefined;
   if (!summarizationApiAvailable) {
-    summarizationUnavailableDialog.showModal();
+    summarizationUnavailableDialog.style.display = 'block';
     return;
   }
 
   const canSummarize = await window.ai.summarizer!.capabilities();
   if (canSummarize.available === 'no') {
-    summarizationUnsupportedDialog.showModal();
+    summarizationUnsupportedDialog.style.display = 'block';
     return;
   }
 
@@ -102,7 +102,7 @@ const initializeApplication = async () => {
       characterCountExceededSpan.classList.add('hidden');
     }
     scheduleSummarization();
-  });  
+  });
 }
 
 initializeApplication();

--- a/summarization-api-playground/src/style.css
+++ b/summarization-api-playground/src/style.css
@@ -71,7 +71,13 @@ h1 {
   line-height: 1.1;
 }
 
-dialog {
+.dialog {
+  display: none;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  padding: 16px;
+  transform: translate(-50%, -50%);
   background-color: darkred;
   border: 1px solid red;
   border-radius: 4px;
@@ -102,7 +108,7 @@ pre {
     background-color: lightgreen;
   }
 
-  dialog {
+  .dialog {
     background-color: lightcoral;
   }
 }

--- a/translation-language-detection-api-playground/index.html
+++ b/translation-language-detection-api-playground/index.html
@@ -9,7 +9,12 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="color-scheme" content="dark light" />
+    <!-- Language Detector API --->
     <meta http-equiv="origin-trial" content="AsBU3QyUBL+Bp/ayVhXIzhF0+sBq5ScCkktyzBQ31GSnYzIQgfy218jUcgXkTaQPzivvIcyWPzLRQpk75rSi8g0AAABYeyJvcmlnaW4iOiJodHRwczovL2Nocm9tZS5kZXY6NDQzIiwiZmVhdHVyZSI6Ikxhbmd1YWdlRGV0ZWN0aW9uQVBJIiwiZXhwaXJ5IjoxNzQ5NTk5OTk5fQ==" />
+
+    <!-- Translator API --->
+    <meta http-equiv="origin-trial" content="Alo80bBNgwjo5MP2/xIIZHcgQxL9iqWFITM6NhdzlgCOzvmNng+WQ8ErO1k5ch7+P168yxsSmMGYdJ0MPqWauw8AAABSeyJvcmlnaW4iOiJodHRwczovL2Nocm9tZS5kZXY6NDQzIiwiZmVhdHVyZSI6IlRyYW5zbGF0aW9uQVBJIiwiZXhwaXJ5IjoxNzUzMTQyNDAwfQ==" />
+
     <link
       rel="icon"
       href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>💬</text></svg>"


### PR DESCRIPTION
- Add origin trial tokens to Language Detector/Translation demo and Summarizer demo.
- Change `<dialog>` to a simple `<div>`, because else it scrolls the demo into sight if it's embedded and the `<dialog>` opens.  