### PR TITLE
Implement workaround for Summarizer capabilities check

### DIFF
--- a/summarization-api-playground/src/main.ts
+++ b/summarization-api-playground/src/main.ts
@@ -29,27 +29,61 @@ const output = document.querySelector('#output') as HTMLDivElement;
  *
  * The function expects the model availability to be either `readily` or `after-download`, so the
  * availability must be checked before calling it. If availability is `no`, the function will throw
- *  an error.
+ * an error.
  */
 const createSummarizationSession = async (
-    type: AISummarizerType,
-    format: AISummarizerFormat,
-    length: AISummarizerLength,
-    downloadProgressListener?: (ev: DownloadProgressEvent) => void): Promise<AISummarizer> =>  {
-  const canSummarize = await window.ai.summarizer!.capabilities();
-  if (canSummarize.available === 'no') {
+  type: AISummarizerType,
+  format: AISummarizerFormat,
+  length: AISummarizerLength,
+  downloadProgressListener?: (ev: DownloadProgressEvent) => void): Promise<AISummarizer> => {
+  let monitor = undefined;
+  if (downloadProgressListener) {
+      monitor = (m: AICreateMonitor) => {
+          m.addEventListener('downloadprogress', downloadProgressListener);
+      };
+  }
+
+  if (!await checkSummarizerSupport()) {
     throw new Error('AI Summarization is not supported');
   }
 
-  let monitor = undefined;
-  if (downloadProgressListener) { 
-    monitor = (m: AICreateMonitor) => {
-      m.addEventListener('downloadprogress', downloadProgressListener);
-    };
+  return window.ai.summarizer.create({ type, format, length, monitor });
+}
+
+/*
+ * Checks if the device supports the Summarizer API (rather than if the browser supports the API).
+ * This method returns `true` when the device is capable of running the Summarizer API and `false`
+ * when it is not.
+ * 
+ * Ideally this check would only require the code code section below:
+ * 
+ * ```javascript
+ * let capabilites = await window.ai.summarizer.capabilities();
+ * if (capabilites.available === 'readily' || capabilites.available === 'after-download') {
+ *   return true;
+ * }
+ * ```
+ * 
+ * However, due to https://crbug.com/379074334, the API may return `no` when
+ * `window.ai.summarizer.create()` was never called, so this function implements a workaround for
+ * this scenario, ensuring `create()` is called at least once before returning `false`.
+ */
+const checkSummarizerSupport = async (): Promise<boolean> => {
+  // Do a first capabilities check. If 'no' is returned, it might mean the model hasn't been
+  // bootstrapped by calling `create()`. In this case, `create()` is called, which should result
+  // in an exception being raised. The exception is ignored, but now `capabilities()` should
+  // reflect the actual state of the API, with `no` meaning the device is unable to run the API.
+  let capabilites = await window.ai.summarizer.capabilities();
+  if (capabilites.available === 'readily' || capabilites.available === 'after-download') {
+    return true;
   }
 
-  const summarizationSession = await window.ai.summarizer!.create({type, format, length, monitor});
-  return summarizationSession;
+  try {
+    await window.ai.summarizer.create();
+  } catch (e) { }
+
+  capabilites = await window.ai.summarizer.capabilities();
+  return capabilites.available !== 'no';
 }
 
 /*
@@ -64,8 +98,8 @@ const initializeApplication = async () => {
     return;
   }
 
-  const canSummarize = await window.ai.summarizer!.capabilities();
-  if (canSummarize.available === 'no') {
+  const canSummarize = await checkSummarizerSupport();
+  if (!canSummarize) {
     summarizationUnsupportedDialog.style.display = 'block';
     return;
   }


### PR DESCRIPTION
Due to https://crbug.com/379074334, `ai.summarizer.capabilities()` can return `no` even though the device is capable, due to `create()` never being called. This PR implements a workaround for this scenario, ensuring that when availability is `no`, `create()` is called, the `capabilities()` is checked again.