### PR TITLE
Remove the all-in-on playground

### DIFF
--- a/landing-pages/index.html
+++ b/landing-pages/index.html
@@ -81,14 +81,6 @@
 
         <div class="demo-grid">
             <div class="demo-card">
-                <img src="images/built-in-ai-playground.png" alt="Screenshot of the Built-in AI Playground" width="288" height="162"/>
-                <h3>Built-in AI Playground</h3>
-                <div>
-                    An all-in-one Playground showcasing every Built-in AI API.
-                </div>
-                <a href="/web-ai-demos/built-in-ai-playground">Open</a>
-            </div>
-            <div class="demo-card">
                 <img src="images/prompt-api-playground.png" alt="Screenshot of the Prompt API Playground" width="288" height="162"/>
                 <h3>Prompt API Playground</h3>
                 <div>


### PR DESCRIPTION
- The playground is broken to the latest version of the APIs.
- We have commitment to maintain the other playgrounds, but not this one. 
- The demo is still available, just not listed in the landing page.