### PR TITLE
Remove the AI Planner for the AI demos landing

### DIFF
--- a/landing-pages/index.html
+++ b/landing-pages/index.html
@@ -129,14 +129,6 @@
                 <a href="/web-ai-demos/prompt-api-weather/">Open</a>
             </div>
             <div class="demo-card">
-                <img src="images/built-in-ai-planning.png" alt="Screenshot of Built-in AI Planning demo" width="288" height="162"/>
-                <h3>Built-in AI Planning</h3>
-                <div>
-                    Break goals into plans and plans into tasks with the help of the <a href="https://developer.chrome.com/docs/extensions/ai/prompt-api">Prompt API</a>.
-                </div>
-                <a href="/web-ai-demos/ai-planning/">Open</a>
-            </div>
-            <div class="demo-card">
                 <img src="images/built-in-ai-session-management.png" alt="Screenshot of Built-in AI Session Management demo" width="288" height="162"/>
                 <h3>Built-in AI Session Management</h3>
                 <div>


### PR DESCRIPTION
The demo is not being maintained and broken because the API surface has changed.