### PR TITLE
Weather AI demo works on new and old API shapes

### DIFF
--- a/weather-ai/src/App.tsx
+++ b/weather-ai/src/App.tsx
@@ -21,15 +21,14 @@ function App() {
   const [location, setLocation] = useState<Location>();
   const [weatherData, setWeatherData] = useState<WeatherResponse>();
   const [weatherApiError, setWeatherApierror] = useState<string>();
-  const [weatherDescription, setWeatherDescription] = useState<string>();
+  const [weatherDescription, setWeatherDescription] = useState<string>('');
   const [weatherDescriptionDone, setWeatherDescriptionDone] = useState<boolean>();
   const [snackbarOpen, setSnackbarOpen] = useState<boolean>(true);
   const [promptApiSupported, setPromptApiSupported] = useState<boolean>(true);
 
   // Checks if the Prompt API is supported.
   useEffect(() => {
-    const supported = window.ai !== undefined && window.ai.languageModel !== undefined;
-    setPromptApiSupported(supported);
+    setPromptApiSupported(BuiltinPrompting.isBuiltinAiSupported());
   }, []);
 
   // Get the user's location from the browser.
@@ -68,10 +67,10 @@ function App() {
 
         try {
           const promptApi = await BuiltinPrompting.createPrompting();
-          if (streaming === 'true') {
+          if (streaming === null || streaming === 'true') {
               const reader = await promptApi.streamingPrompt(prompt);
               for await (const chunk of reader) {
-                setWeatherDescription(chunk);
+                setWeatherDescription(w => w + chunk);
               }
               setWeatherDescriptionDone(true);
           } else {

--- a/weather-ai/src/lib/prompting/index.ts
+++ b/weather-ai/src/lib/prompting/index.ts
@@ -2,8 +2,18 @@
  * Copyright 2024 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
+
+// Declare LanguageModal and ai as globals, to avoid the TS compilar complainig about unknown
+// objects in the global scope.
+declare global {
+  interface Window {
+      LanguageModel: any;
+      ai: any;
+  }
+}
+
 export default class BuiltinPrompting {
-    constructor(private session: AILanguageModel) {}
+    constructor(private session: any) {}
 
     streamingPrompt(prompt: string): AsyncIterable<string> {
         // The below typecasts ReadableStream<string> to AsyncIterable<string> as DefinitelyTyped
@@ -16,12 +26,24 @@ export default class BuiltinPrompting {
         return this.session.prompt(prompt);
     }
 
+    static isBuiltinAiSupported(): boolean {
+        return (window.ai !== undefined && window.ai.languageModel !== undefined) || window.LanguageModel !== undefined;
+    }
+
     static async createPrompting(): Promise<BuiltinPrompting> {
-        if ((await LanguageModel.availability()) === 'available') {
-            let session = await LanguageModel.create();
+        // The newer version of the API, currently in Chrome Canary, uses `window.LanguageModel`,
+        // while the version currently on stable uses window.ai.languageModel. So we this code
+        // handles the two paths. This method also expects `isBuiltinAiSupported()` to have been
+        // called first.
+        if (window.LanguageModel && (await window.LanguageModel.availability()) === 'available') {
+            let session = await window.LanguageModel.create();
+            return new BuiltinPrompting(session);
+        } else if (window.ai.languageModel && (await window.ai.languageModel.capabilities()).available === 'readily') {
+            let session = await window.ai.languageModel.create();
             return new BuiltinPrompting(session);
         } else {
             throw new Error("Built-in prompting not supported");
         }
     }
 }
+


### PR DESCRIPTION
- Changes the weather demo to work with both the `window.ai.languageModel` namespace and `window.LanguageModel` namespace.
- Handles using the `availability()` method for `window.LanguageModel()` and `capabilities()` for
`window.ai.languageModel()`
- Moves feature detection code from App.tsx to prompting/index.ts, to keep all the Prompt API related code in a single file.
- Changes default for the demo to stream the LLM response, as the API is now stable and streaming works consistently.