### PR TITLE
Prompt API Playground accepts old and new API shape

### DIFF
--- a/prompt-api-playground/index.html
+++ b/prompt-api-playground/index.html
@@ -49,7 +49,7 @@
           <input
           id="session-temperature"
           type="number"
-          step="any"
+          step="0.1"
           min="0"
         >
         </div>


### PR DESCRIPTION
- Updates the Prompt API playground to accept both the API shape currently behind a flag in Chrome stable and the API shape currently behind a flag in Chrome Canary.
- Updates the step for temperature to 0.1, for more granular control of the temperature.