### PR TITLE
ai-streaming-parser accepts old and new API shapes.

### DIFF
--- a/ai-streaming-parser/script.js
+++ b/ai-streaming-parser/script.js
@@ -6,7 +6,9 @@
 import * as smd from 'https://cdn.jsdelivr.net/npm/streaming-markdown@0.0.17/smd.min.js';
 import DOMPurify from 'https://cdn.jsdelivr.net/npm/dompurify@3.2.0/dist/purify.es.mjs';
 
-if (!('LanguageModel' in self)) {
+// The Prompt API has a different API shape in Chrome Canary than the one behind a flag
+// in Chrome stable. The availability check below verifies both API shapes.
+if (!('LanguageModel' in self) && !('ai' in self) && !('languageModel' in self.ai)) {
   document.querySelector('.not-supported').style.display = 'block';
   document.querySelector('main').style.display = 'none';
 }
@@ -16,7 +18,10 @@ const pre = document.querySelector('pre');
 const input = document.querySelector('input');
 const output = document.querySelector('output');
 
-const assistant = await LanguageModel.create();
+// If the new API shape `LanguageModel` is available use it, otherwise use the previous
+// namespace `ai.languageModel`.
+const assistant = ('LanguageModel' in self) ?
+    await LanguageModel.create() : await ai.languageModel.create();
 
 const renderer = smd.default_renderer(output);
 const parser = smd.parser(renderer);


### PR DESCRIPTION
-Update the ai-streaming-parser demo to use both the previous API shape available in Chrome stable and the new one used in Chrome Canary.