### PR TITLE
Fixed issue with rewriter output. Update script.js

### DIFF
--- a/writer-rewriter-api-playground/script.js
+++ b/writer-rewriter-api-playground/script.js
@@ -134,14 +134,14 @@ import DOMPurify from 'https://cdn.jsdelivr.net/npm/dompurify@3.1.6/dist/purify.
       return;
     }
     output.textContent = 'Rewriting…';
-    const stream = await rewriter.rewriteStreaming(prompt);
+    const stream = rewriter.rewriteStreaming(prompt);
     output.textContent = '';
     let fullResponse = '';
     for await (const chunk of stream) {
       // In Chrome stable, the rewriter always returns the entire text, so the full response is
       // the same as the chunk. In Canary, only the newly generated content is returned, so
       // the new chunk is joined with the existing full response.
-      fullResponse = 'Rewriter' in self ? fullResponse + chunk.trim() : chunk.trim();
+      fullResponse = 'Rewriter' in self ? fullResponse + chunk : chunk;
       output.innerHTML = DOMPurify.sanitize(
         fullResponse /*marked.parse(fullResponse)*/
       );


### PR DESCRIPTION
Thanks for great examples for WEB AI API. 
I played with one, and noticed issues with rewriter output, It was concatenated all words into one without spaces. I have fixed them. 
<img width="1063" alt="Rewriter-issue" src="https://github.com/user-attachments/assets/f7e93b13-c639-4905-a35f-35b9df8c8307" />
