### PR TITLE
Summarizer Playground uses measureInputUsage / inputQuota

### DIFF
--- a/summarization-api-playground/index.html
+++ b/summarization-api-playground/index.html
@@ -23,7 +23,7 @@
         <fieldset>
           <legend>Prompt</legend>
           <textarea id="input"></textarea>
-          <div>Character Count: <span id="character-count">0</span><span id="character-count-exceed" class="hidden"> (may exceed maximum token limit supported by the API.)</span></div>
+          <div>Token Usage: <span id="character-count"></span></div>
         </fieldset>
         <fieldset>
           <legend>Settings</legend>


### PR DESCRIPTION
 - Update the Summarizer Playground demo to use `measureInputUsage` and `inputQuota` instead of fixed values.
 - Removes usage of the old API shape as Chrome stable now uses the new API shape.