### PR TITLE
Use the availability method to test whether a language pair is unavailable

### DIFF
--- a/translation-language-detection-api-playground/script.js
+++ b/translation-language-detection-api-playground/script.js
@@ -4,9 +4,8 @@
  */
 
 (async () => {
-  // The Language Detector API uses the `self.LanguageDetector` namespace in Canary, but
-  // `ai.languageDetector` in Stable, so both shapes are feature detected.
-  if (!('LanguageDetector' in self) && !('ai' in self) && !('languageDetector' in self.ai)) {
+  // The Language Detector API uses the `self.LanguageDetector` namespace.
+  if (!('LanguageDetector' in self)) {
     document.querySelector('.not-supported-message').hidden = false;
     return;
   }
@@ -19,8 +18,7 @@
 
   form.style.visibility = 'visible';
   // The code below handles creation of a language detector in either stable or canary.
-  const detector = await
-      ('LanguageDetector' in self ? LanguageDetector.create() : ai.languageDetector.create());
+  const detector = await LanguageDetector.create();
 
   input.addEventListener('input', async () => {
     if (!input.value.trim()) {
@@ -47,9 +45,8 @@
     return displayNames.of(languageTag);
   };
 
-  // The Translator API uses the `self.Translator` namespace in Canary, but
-  // `ai.translator` in Stable, so both shapes are feature detected.
-  if ('Translator' in self || ('ai' in self && 'translator' in self.ai)) {
+  // The Translator API uses the `self.Translator` namespace in Canary and Stable.
+  if ('Translator' in self) {
     document.querySelectorAll('[hidden]:not(.not-supported-message)').forEach((el) => {
       el.removeAttribute('hidden');
     });
@@ -61,19 +58,17 @@
         const targetLanguage = language.value;
 
         // use availability for the Translator API
-        const unavailable = await ('Translator' in self? Translator.availability({ sourceLanguage, targetLanguage }) === 'unavailable'
-            : ai.translator.availability({ sourceLanguage, targetLanguage }) === 'no');
+        const availability = await Translator.availability({ sourceLanguage, targetLanguage });        
+        const isUnavailable = availability !== 'available';
                        
-        if (unavailable) {
+        if (isUnavailable) {
           const displaySourceLanguage = languageTagToHumanReadable(sourceLanguage, 'en') || ''; 
           const displayTargetLanguage = languageTagToHumanReadable(targetLanguage, 'en') || ''; 
           output.textContent = `${displaySourceLanguage} - ${displayTargetLanguage} pair is not supported.`;
           return;
         }
         // The code below handles creation of a translator in either stable or canary.
-        const translator = await ('Translator' in self ?
-            Translator.create({ sourceLanguage, targetLanguage }) :
-            ai.translator.create({ sourceLanguage, targetLanguage }));
+        const translator = await Translator.create({ sourceLanguage, targetLanguage });
         output.textContent = await translator.translate(input.value.trim());
       } catch (err) {
         output.textContent = 'An error occurred. Please try again.';

--- a/translation-language-detection-api-playground/script.js
+++ b/translation-language-detection-api-playground/script.js
@@ -17,7 +17,6 @@
   const language = document.querySelector('select');
 
   form.style.visibility = 'visible';
-  // The code below handles creation of a language detector in either stable or canary.
   const detector = await LanguageDetector.create();
 
   input.addEventListener('input', async () => {
@@ -45,7 +44,6 @@
     return displayNames.of(languageTag);
   };
 
-  // The Translator API uses the `self.Translator` namespace in Canary and Stable.
   if ('Translator' in self) {
     document.querySelectorAll('[hidden]:not(.not-supported-message)').forEach((el) => {
       el.removeAttribute('hidden');
@@ -57,7 +55,6 @@
         const sourceLanguage = (await detector.detect(input.value.trim()))[0].detectedLanguage;
         const targetLanguage = language.value;
 
-        // use availability for the Translator API
         const availability = await Translator.availability({ sourceLanguage, targetLanguage });        
         const isUnavailable = availability !== 'available';
                        
@@ -67,7 +64,6 @@
           output.textContent = `${displaySourceLanguage} - ${displayTargetLanguage} pair is not supported.`;
           return;
         }
-        // The code below handles creation of a translator in either stable or canary.
         const translator = await Translator.create({ sourceLanguage, targetLanguage });
         output.textContent = await translator.translate(input.value.trim());
       } catch (err) {

--- a/translation-language-detection-api-playground/script.js
+++ b/translation-language-detection-api-playground/script.js
@@ -58,11 +58,18 @@
       e.preventDefault();
       try {
         const sourceLanguage = (await detector.detect(input.value.trim()))[0].detectedLanguage;
-        if (!['en', 'ja', 'es'].includes(sourceLanguage)) {
-          output.textContent = 'Currently, only English ↔ Spanish and English ↔ Japanese are supported.';
+        const targetLanguage = language.value;
+
+        // use availability for the Translator API
+        const unavailable = await ('Translator' in self? Translator.availability({ sourceLanguage, targetLanguage }) === 'unavailable'
+            : ai.translator.availability({ sourceLanguage, targetLanguage }) === 'no');
+                       
+        if (unavailable) {
+          const displaySourceLanguage = languageTagToHumanReadable(sourceLanguage, 'en') || ''; 
+          const displayTargetLanguage = languageTagToHumanReadable(targetLanguage, 'en') || ''; 
+          output.textContent = `${displaySourceLanguage} - ${displayTargetLanguage} pair is not supported.`;
           return;
         }
-        const targetLanguage = language.value;
         // The code below handles creation of a translator in either stable or canary.
         const translator = await ('Translator' in self ?
             Translator.create({ sourceLanguage, targetLanguage }) :


### PR DESCRIPTION
The new and  old APIs use the availability static method to test whether the pair is unavailable. 

When the new API returns "unavailable", the translation does not happen.
When the new API returns "no", the translation does not happen.
