### PR TITLE
Fix canvas-image-prompt transparency issue

### DIFF
--- a/canvas-image-prompt/script.js
+++ b/canvas-image-prompt/script.js
@@ -36,13 +36,10 @@ canvas.height = referenceImage.height;
 
 let isPainting = false;
 
-const ctx = canvas.getContext("2d");
-ctx.fillStyle = "white";
-ctx.fillRect(0, 0, canvas.width, canvas.height);
+const ctx = canvas.getContext("2d", { alpha: false });
 ctx.lineWidth = 4;
 ctx.lineCap = "round";
-ctx.strokeStyle = "black";
-
+ctx.strokeStyle = "white";
 
 const draw = ({ clientX, clientY }) => {
   if (isPainting) {


### PR DESCRIPTION
The demo is broken due to the black line on a transparent background (rasterized black internally).
Ensure the canvas is filled white and the line is drawn black, so the model can "see the drawing".