### PR TITLE
Make Proofreader demo work with `type` or `types`

### DIFF
--- a/proofreader-api-playground/fake.json
+++ b/proofreader-api-playground/fake.json
@@ -5,63 +5,63 @@
       "startIndex": 5,
       "endIndex": 8,
       "correction": "is",
-      "type": "grammar",
+      "types": ["grammar"],
       "explanation": "The singular 'This' requires 'is' instead of 'are'."
     },
     {
       "startIndex": 11,
       "endIndex": 17,
       "correction": "random",
-      "type": "spelling",
+      "types": ["spelling"],
       "explanation": "'radnom' is a misspelling of 'random'."
     },
     {
       "startIndex": 40,
       "endIndex": 43,
       "correction": "c, c",
-      "type": "punctuation",
+      "types": ["punctuation"],
       "explanation": "A comma is needed between 'classic' and 'common' for clarity."
     },
     {
       "startIndex": 54,
       "endIndex": 61,
       "correction": "typical",
-      "type": "spelling",
+      "types": ["spelling"],
       "explanation": "'typicla' is a misspelling of 'typical'."
     },
     {
       "startIndex": 62,
       "endIndex": 67,
       "correction": "typos",
-      "type": "spelling",
+      "types": ["spelling"],
       "explanation": "'typso' is a misspelling of 'typos'."
     },
     {
       "startIndex": 80,
       "endIndex": 85,
       "correction": "issues",
-      "type": "spelling",
+      "types": ["spelling"],
       "explanation": "'issus' is a misspelling of 'issues'."
     },
     {
       "startIndex": 87,
       "endIndex": 90,
       "correction": "The",
-      "type": "capitalization",
+      "types": ["capitalization"],
       "explanation": "'the' should be capitalized after a period."
     },
     {
       "startIndex": 107,
       "endIndex": 115,
       "correction": "hopefully",
-      "type": "spelling",
+      "types": ["spelling"],
       "explanation": "'hopefuly' is a misspelling of 'hopefully'."
     },
     {
       "startIndex": 141,
       "endIndex": 143,
       "correction": "on",
-      "type": "preposition",
+      "types": ["preposition"],
       "explanation": "The preposition 'at' should be 'on'."
     },
 
@@ -69,7 +69,7 @@
       "startIndex": 151,
       "endIndex": 154,
       "correction": "d fingers c",
-      "type": "missing-words",
+      "types": ["missing-words"],
       "explanation": "There was the word 'fingers' missing."
     }
   ]

--- a/proofreader-api-playground/index.html
+++ b/proofreader-api-playground/index.html
@@ -2,70 +2,79 @@
   Copyright 2025 Google LLC
   SPDX-License-Identifier: Apache-2.0
  -->
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-	<head>
-		<meta charset="utf-8">
-		<meta name="viewport" content="width=device-width, initial-scale=1">
-		<meta name="color-scheme" content="dark light">
-		<meta http-equiv="origin-trial" content="AlTsndqq95JpJiuNYyfn5+1O9qFyQJjL36Fna+RrhgNahpqK1zDCI6IRuYOlP/yu+1XFizuq5XyHKsxnOpdG0wYAAABUeyJvcmlnaW4iOiJodHRwczovL2Nocm9tZS5kZXY6NDQzIiwiZmVhdHVyZSI6IkFJUHJvb2ZyZWFkZXJBUEkiLCJleHBpcnkiOjE3NzkxNDg4MDB9">
-		<link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>✍️</text></svg>">
-		<title>Proofreader API</title>
-		<link rel="stylesheet" href="style.css">
-		<script>
-			if (!isSecureContext) location.protocol = 'https:';
-		</script>
-		<script src="script.js" type="module"></script>
-	</head>
-	<body>
-		<h1>✍️ Proofreader API</h1>
-		<p class="error" hidden>
-			😕 Your browser doesn't support the Proofreader API. Using static
-			<a href="fake.json">mockup data</a>.
-		</p>
-		<h2>Input text</h2>
-		<p>
-			<label class="legend" for="examples">Legend:</label>
-			<!-- Zero-width space (&#8203;) for invisibly creating the CSS Highlight "other". -->
-			<!-- prettier-ignore -->
-			<span id="examples">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="color-scheme" content="dark light" />
+    <meta
+      http-equiv="origin-trial"
+      content="AlTsndqq95JpJiuNYyfn5+1O9qFyQJjL36Fna+RrhgNahpqK1zDCI6IRuYOlP/yu+1XFizuq5XyHKsxnOpdG0wYAAABUeyJvcmlnaW4iOiJodHRwczovL2Nocm9tZS5kZXY6NDQzIiwiZmVhdHVyZSI6IkFJUHJvb2ZyZWFkZXJBUEkiLCJleHBpcnkiOjE3NzkxNDg4MDB9"
+    />
+    <link
+      rel="icon"
+      href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>✍️</text></svg>"
+    />
+    <title>Proofreader API</title>
+    <link rel="stylesheet" href="style.css" />
+    <script>
+      if (!isSecureContext) location.protocol = 'https:';
+    </script>
+    <script src="script.js" type="module"></script>
+  </head>
+  <body>
+    <h1>✍️ Proofreader API</h1>
+    <p class="error" hidden>
+      😕 Your browser doesn't support the Proofreader API. Using static
+      <a href="fake.json">mockup data</a>.
+    </p>
+    <h2>Input text</h2>
+    <p>
+      <label class="legend" for="examples">Legend:</label>
+      <!-- Zero-width space (&#8203;) for invisibly creating the CSS Highlight "other". -->
+      <!-- prettier-ignore -->
+      <span id="examples">
 				Spelling Punctuation Capitalization Preposition Missing&nbsp;words Grammar &#8203;
 			</span>
-		</p>
-		<form>
-			<!-- prettier-ignore -->
-			<div contenteditable="plaintext-only"
+    </p>
+    <form>
+      <!-- prettier-ignore -->
+      <div contenteditable="plaintext-only"
 			     spellcheck="false"
 			     tabindex="0"
 			>This are a radnom text with a few classic common, and typicla typso and grammar issus. the Proofreader API hopefuly finds them all. Knocking at wood and crossed.</div>
 
-			<label><input type="checkbox" id="include-correction-types">
-			Include
-			correction types</label>
-			<label hidden><input type="checkbox" id="include-correction-explanations" disabled>
-			Include correction explanations</label>
+      <label
+        ><input type="checkbox" id="include-correction-types" /> Include
+        correction types</label
+      >
+      <label hidden
+        ><input type="checkbox" id="include-correction-explanations" disabled />
+        Include correction explanations</label
+      >
 
-			<button disabled type="submit">✍️ Proofread</button>
+      <button disabled type="submit">✍️ Proofread</button>
 
-			<span class="activity-indicator"></span>
-		</form>
-		<h2>Corrected text</h2>
-		<output></output>
-		<div popover="auto">
-			<h1></h1>
-			<div>
-				<strong>Correction:</strong>
-				<button type="button" class="correction"></button>
-			</div>
-			<div hidden>
-				<strong>Explanation:</strong>
-				<span class="explanation"></span>
-			</div>
-		</div>
-		<footer>
-			Made by
-			<a href="https://github.com/tomayac/">@tomayac</a>. Source code on
-			<a href="https://github.com/GoogleChromeLabs/web-ai-demos">GitHub</a>.
-		</footer>
-	</body>
+      <span class="activity-indicator"></span>
+    </form>
+    <h2>Corrected text</h2>
+    <output></output>
+    <div popover="auto">
+      <h1></h1>
+      <div>
+        <strong>Correction:</strong>
+        <button type="button" class="correction"></button>
+      </div>
+      <div hidden>
+        <strong>Explanation:</strong>
+        <span class="explanation"></span>
+      </div>
+    </div>
+    <footer>
+      Made by
+      <a href="https://github.com/tomayac/">@tomayac</a>. Source code on
+      <a href="https://github.com/GoogleChromeLabs/web-ai-demos">GitHub</a>.
+    </footer>
+  </body>
 </html>

--- a/proofreader-api-playground/script.js
+++ b/proofreader-api-playground/script.js
@@ -30,7 +30,7 @@ const legendContainer = document.querySelector('p:has(.legend)');
     preposition: null,
     'missing-words': null,
     grammar: null,
-     // Fallback for when `includeCorrectionTypes` is `false`.
+    // Fallback for when `includeCorrectionTypes` is `false`.
     other: null,
   };
   const errorTypes = Object.keys(errorHighlights);
@@ -76,11 +76,23 @@ const legendContainer = document.querySelector('p:has(.legend)');
     });
 
   if ('highlightsFromPoint' in self.HighlightRegistry.prototype) {
-    document.addEventListener('click', (event) => {
-      const mouseX = event.clientX;
-      const mouseY = event.clientY;
-      // ToDo: Make the error clicking logic based on CSS Highlights.
-      console.log(CSS.highlights.highlightsFromPoint(mouseX, mouseY));
+    input.addEventListener('click', (event) => {
+      const hits = CSS.highlights.highlightsFromPoint(
+        event.clientX,
+        event.clientY
+      );
+      if (hits.length > 0) {
+        const hitRange = hits[0].ranges[0];
+        // Find the correction that matches this range.
+        currentCorrection = corrections.find(
+          (c) =>
+            c.range.startOffset === hitRange.startOffset &&
+            c.range.endOffset === hitRange.endOffset
+        );
+        if (currentCorrection) {
+          showCorrectionsAtCaretPosition(currentCorrection);
+        }
+      }
     });
   }
 
@@ -117,60 +129,92 @@ const legendContainer = document.querySelector('p:has(.legend)');
       return;
     }
 
-    if (proofreaderAPISupported) {
-      // Work with `innerText` here.
-      ({ correctedInput, corrections } = await proofreader.proofread(
-        input.innerText
-      ));
-    } else {
-      // Use fake data.
-      ({ correctedInput, corrections } = await (
-        await fetch('fake.json')
-      ).json());
+    let result;
+    try {
+      if (proofreaderAPISupported) {
+        // Work with `innerText` here.
+        result = await proofreader.proofread(input.innerText);
+      } else {
+        // Use fake data.
+        result = await (await fetch('fake.json')).json();
+      }
+    } catch (err) {
+      if (err.name === 'AbortError') {
+        console.log('Proofreading aborted.');
+        return;
+      }
+      throw err;
     }
+
+    const { correctedInput: newCorrectedInput, corrections: newCorrections } =
+      result;
+
     activityIndicator.textContent = '';
-    if (!corrections) {
-      corrections = [];
-    }
+    const tempCorrections = newCorrections || [];
+
     // Highlight all corrections by type.
     const textNode = input.firstChild;
-    for (const correction of corrections) {
+    for (const correction of tempCorrections) {
       const range = new Range();
       range.setStart(textNode, correction.startIndex);
       range.setEnd(textNode, correction.endIndex);
-      correction.type ||= 'other';
-      errorHighlights[correction.type].add(range);
+
+      // Defensively handle both `type` and `types`.
+      if (!correction.types && correction.type) {
+        correction.types = [correction.type];
+      }
+      correction.types ||= ['other'];
+
+      // Store the range in the correction object for later use in clicking and positioning.
+      correction.range = range;
+
+      // Apply highlighting for all matching types.
+      for (const type of correction.types) {
+        const highlightKey = errorHighlights[type] ? type : 'other';
+        errorHighlights[highlightKey].add(range);
+      }
+
+      // Store the joined types as a string for display in the popover.
+      correction.typesString = correction.types.join(', ');
     }
+
+    // Only update global state after processing is complete.
+    corrections = tempCorrections;
+    correctedInput = newCorrectedInput;
 
     if (correctedInput) {
       output.textContent = correctedInput;
     }
   });
 
-  const showCorrectionsAtCaretPosition = () => {
+  const showCorrectionsAtCaretPosition = (hitCorrection) => {
     if (!corrections || !Array.isArray(corrections)) {
       return;
     }
 
-    // Find the caret position index and coordinates to position the popup.
+    // Find the current selection or hit.
     let selection = window.getSelection();
+    if (!selection.rangeCount) return;
     let range = selection.getRangeAt(0);
-    let preCaretRange = range.cloneRange();
-    preCaretRange.selectNodeContents(input);
-    preCaretRange.setEnd(range.endContainer, range.endOffset);
-    const caretPosition = preCaretRange.toString().length;
-    let rect = preCaretRange.getBoundingClientRect();
-    let { left, width, top, height } = rect;
-    left += width / 2;
-    top += height;
 
-    // Find corrections at caret.
-    currentCorrection =
-      corrections.find(
-        (correction) =>
-          correction.startIndex <= caretPosition &&
-          caretPosition <= correction.endIndex
-      ) || null;
+    // If a hitCorrection was passed (from a click), use it.
+    // Otherwise, find it by caret position.
+    currentCorrection = hitCorrection;
+    if (!currentCorrection) {
+      let preCaretRange = range.cloneRange();
+      preCaretRange.selectNodeContents(input);
+      preCaretRange.setEnd(range.endContainer, range.endOffset);
+      const caretPosition = preCaretRange.toString().length;
+
+      // Find corrections at caret.
+      currentCorrection =
+        corrections.find(
+          (correction) =>
+            correction.startIndex <= caretPosition &&
+            caretPosition <= correction.endIndex
+        ) || null;
+    }
+
     if (!currentCorrection) {
       popover.hidePopover();
       form
@@ -179,15 +223,35 @@ const legendContainer = document.querySelector('p:has(.legend)');
       return;
     }
 
+    // Calculate position based on the correction's range.
+    if (!currentCorrection.range) {
+      return;
+    }
+    const rect = currentCorrection.range.getBoundingClientRect();
+    let { left, width, top, height } = rect;
+    left += width / 2;
+    top += height;
+
     // Show the popup.
-    const { type, correction, explanation } = currentCorrection;
-    const heading = type[0].toUpperCase() + type.substring(1).replace(/-/, ' ');
+    const { typesString, correction, explanation, types } = currentCorrection;
+    const heading =
+      typesString[0].toUpperCase() +
+      typesString.substring(1).replace(/-/g, ' ');
     popover.querySelector('h1').textContent = heading;
     const text = popover.querySelector('h1').firstChild;
     const highlightRange = new Range();
     highlightRange.setStart(text, 0);
     highlightRange.setEnd(text, heading.length);
-    errorHighlights[type].add(highlightRange);
+
+    // Apply all highlights to the heading in the popover.
+    if (Array.isArray(types)) {
+      for (const type of types) {
+        const highlightKey = errorHighlights[type] ? type : 'other';
+        errorHighlights[highlightKey].add(highlightRange);
+      }
+    } else {
+      errorHighlights['other'].add(highlightRange);
+    }
     popover.querySelector('.correction').textContent =
       correction || '[Remove word]';
     if (explanation) {
@@ -230,6 +294,13 @@ const legendContainer = document.querySelector('p:has(.legend)');
     )}${correction}${input.textContent.substring(endIndex)}`;
     popover.hidePopover();
     submit.click();
+  });
+
+  input.addEventListener('keydown', (e) => {
+    if (e.key === 'Tab' && popover.matches(':popover-open')) {
+      e.preventDefault();
+      button.focus();
+    }
   });
 
   input.addEventListener('keyup', (e) => {


### PR DESCRIPTION
The API recently changed from `ProofreadCorrection.type` (singular) to `ProofreadCorrection.types` (plural). This PR makes sure the demo works with both. 