### PR TITLE
Support latest contextWindow and contextUsage names in Prompt API

### DIFF
--- a/prompt-api-playground/index.html
+++ b/prompt-api-playground/index.html
@@ -2,18 +2,21 @@
   Copyright 2024 Google LLC
   SPDX-License-Identifier: Apache-2.0
  -->
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="color-scheme" content="dark light">
-    <meta http-equiv="origin-trial" content="AoXwZGsUZlGEyuueX5nR6tujynrCfWhNWQnZcHTy3AZkXtCMULt/UJs6+/1Bp5jVw7Ue96Tcyf1IO8IRUMimAgcAAABeeyJvcmlnaW4iOiJodHRwczovL2Nocm9tZS5kZXY6NDQzIiwiZmVhdHVyZSI6IkFJUHJvbXB0QVBJTXVsdGltb2RhbElucHV0IiwiZXhwaXJ5IjoxNzc0MzEwNDAwfQ==">
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="color-scheme" content="dark light" />
+    <meta
+      http-equiv="origin-trial"
+      content="AoXwZGsUZlGEyuueX5nR6tujynrCfWhNWQnZcHTy3AZkXtCMULt/UJs6+/1Bp5jVw7Ue96Tcyf1IO8IRUMimAgcAAABeeyJvcmlnaW4iOiJodHRwczovL2Nocm9tZS5kZXY6NDQzIiwiZmVhdHVyZSI6IkFJUHJvbXB0QVBJTXVsdGltb2RhbElucHV0IiwiZXhwaXJ5IjoxNzc0MzEwNDAwfQ=="
+    />
     <link
       rel="icon"
       href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>✨</text></svg>"
-    >
-    <link rel="stylesheet" href="style.css">
+    />
+    <link rel="stylesheet" href="style.css" />
     <title>Prompt API Playground</title>
     <script>
       if (!isSecureContext) location.protocol = "https:";
@@ -24,9 +27,9 @@
     <h1>✨ Prompt API Playground</h1>
     <p>
       This is a demo of Chrome's
-      <a
-        href="https://developer.chrome.com/docs/ai/built-in"
-      >built-in Prompt API</a>
+      <a href="https://developer.chrome.com/docs/ai/built-in"
+        >built-in Prompt API</a
+      >
       powered by Gemini Nano.
     </p>
     <div id="error-message"></div>
@@ -65,8 +68,9 @@
       </details>
       <button id="copy-link-button">Copy link</button>
       <small
-      >💡 If there's a problem with the response, select the problematic text
-         with your mouse before clicking the button.</small>
+        >💡 If there's a problem with the response, select the problematic text
+        with your mouse before clicking the button.</small
+      >
       <div id="problematic-area">
         <h2>Problematic:</h2>
         <pre id="problem"></pre>

--- a/prompt-api-playground/script.js
+++ b/prompt-api-playground/script.js
@@ -29,7 +29,7 @@ const SYSTEM_PROMPT = "You are a helpful and friendly assistant.";
 
   let session = null;
 
-  if (!('LanguageModel' in self)) {
+  if (!("LanguageModel" in self)) {
     errorMessage.style.display = "block";
     errorMessage.innerHTML = `Your browser doesn't support the Prompt API. If you're on Chrome, join the <a href="https://goo.gle/chrome-ai-dev-preview-join">Early Preview Program</a> to enable it.`;
     return;
@@ -62,11 +62,12 @@ const SYSTEM_PROMPT = "You are a helpful and friendly assistant.";
       }
       const stream = await session.promptStreaming(prompt);
 
-      let result = '';
-      let previousChunk = '';
+      let result = "";
+      let previousChunk = "";
       for await (const chunk of stream) {
         const newChunk = chunk.startsWith(previousChunk)
-            ? chunk.slice(previousChunk.length) : chunk;
+          ? chunk.slice(previousChunk.length)
+          : chunk;
         result += newChunk;
         p.innerHTML = DOMPurify.sanitize(marked.parse(result));
         rawResponse.innerText = result;
@@ -92,19 +93,24 @@ const SYSTEM_PROMPT = "You are a helpful and friendly assistant.";
     }
 
     const numberFormat = new Intl.NumberFormat(NUMBER_FORMAT_LANGUAGE);
-    const decimalNumberFormat = new Intl.NumberFormat(
-      NUMBER_FORMAT_LANGUAGE,
-      { minimumFractionDigits: 1, maximumFractionDigits: 1 },
-    );
+    const decimalNumberFormat = new Intl.NumberFormat(NUMBER_FORMAT_LANGUAGE, {
+      minimumFractionDigits: 1,
+      maximumFractionDigits: 1,
+    });
 
     // In the new API shape, currently in Chrome Canary, `session.maxTokens` was renamed to
     // `session.inputQuota` and `session.tokensSoFar` was renamed to `session.inputUsage`.
     // `session.tokensSoFar` was removed, but the value can be calculated by subtracting
     // `inputUsage` from `inputQuota`. Both APIs shapes are checked in the code below.
-    maxTokensInfo.textContent = numberFormat.format(session.inputQuota || session.maxTokens);
-    tokensLeftInfo.textContent =
-        numberFormat.format(session.tokensSoFar || session.inputQuota - session.inputUsage);
-    tokensSoFarInfo.textContent = numberFormat.format(session.inputUsage || session.tokensSoFar);
+    maxTokensInfo.textContent = numberFormat.format(
+      session.inputQuota || session.maxTokens,
+    );
+    tokensLeftInfo.textContent = numberFormat.format(
+      session.tokensSoFar || session.inputQuota - session.inputUsage,
+    );
+    tokensSoFarInfo.textContent = numberFormat.format(
+      session.inputUsage || session.tokensSoFar,
+    );
   };
 
   const params = new URLSearchParams(location.search);
@@ -151,7 +157,7 @@ const SYSTEM_PROMPT = "You are a helpful and friendly assistant.";
     if (!cost) {
       return;
     }
-    costSpan.textContent = `${cost} token${cost === 1 ? '' : 's'}`;
+    costSpan.textContent = `${cost} token${cost === 1 ? "" : "s"}`;
   });
 
   const resetUI = () => {
@@ -201,9 +207,9 @@ const SYSTEM_PROMPT = "You are a helpful and friendly assistant.";
       session = await LanguageModel.create({
         initialPrompts: [
           {
-            role: 'system',
+            role: "system",
             content: SYSTEM_PROMPT,
-          }
+          },
         ],
       });
     }

--- a/prompt-api-playground/script.js
+++ b/prompt-api-playground/script.js
@@ -98,18 +98,22 @@ const SYSTEM_PROMPT = "You are a helpful and friendly assistant.";
       maximumFractionDigits: 1,
     });
 
-    // In the new API shape, currently in Chrome Canary, `session.maxTokens` was renamed to
+    // In the latest API shape, currently in Chrome Canary, `session.inputQuota` was
+    // renamed to `session.contextWindow` and `session.inputUsage` was renamed to
+    // `session.contextUsage`. Previously `session.maxTokens` was renamed to
     // `session.inputQuota` and `session.tokensSoFar` was renamed to `session.inputUsage`.
     // `session.tokensSoFar` was removed, but the value can be calculated by subtracting
-    // `inputUsage` from `inputQuota`. Both APIs shapes are checked in the code below.
+    // `inputUsage` from `inputQuota`. All APIs shapes are checked in the code below.
     maxTokensInfo.textContent = numberFormat.format(
-      session.inputQuota || session.maxTokens,
+      session.contextWindow || session.inputQuota || session.maxTokens,
     );
     tokensLeftInfo.textContent = numberFormat.format(
-      session.tokensSoFar || session.inputQuota - session.inputUsage,
+      session.tokensSoFar ||
+        session.contextWindow - session.contextUsage ||
+        session.inputQuota - session.inputUsage,
     );
     tokensSoFarInfo.textContent = numberFormat.format(
-      session.inputUsage || session.tokensSoFar,
+      session.contextUsage || session.inputUsage || session.tokensSoFar,
     );
   };
 
@@ -145,11 +149,14 @@ const SYSTEM_PROMPT = "You are a helpful and friendly assistant.";
 
     let cost;
 
-    // The API that returns the token count for a prompt changed between Chrome Stable and Canary
-    // and the method was renamed from `countPromptTokens(input)` to `measureInputUsage(input)`.
-    // The code below ensures both cases are handled.
+    // The API that returns the token count for a prompt has been renamed
+    // from `countPromptTokens(input)` to `measureInputUsage(input)` to
+    // `measureContextUsage(input)`.
+    // The code below ensures all cases are handled.
     if (session.countPromptTokens) {
       cost = await session.countPromptTokens(value);
+    } else if (session.measureContextUsage) {
+      cost = await session.measureContextUsage(value);
     } else if (session.measureInputUsage) {
       cost = await session.measureInputUsage(value);
     }

--- a/prompt-api-playground/script.js
+++ b/prompt-api-playground/script.js
@@ -142,6 +142,10 @@ const SYSTEM_PROMPT = "You are a helpful and friendly assistant.";
   });
 
   promptInput.addEventListener("input", async () => {
+    if (!session) {
+      return;
+    }
+
     const value = promptInput.value.trim();
     if (!value) {
       return;


### PR DESCRIPTION
Token counts on the latest Chrome Canary are broken because of [the latest rename](https://github.com/webmachinelearning/prompt-api/blob/8c88a6022af8014a3b9d8ce64fd375e5de8d713f/README.md?plain=1#L62-L71) in the spec.

The first commit here is just running `npm run fix` because it apparently hadn't been run in a while, so needed a clean slate for the new changes.

Last commit is fixing an existing issue that was causing problems during validating these changes.