### PR TITLE
Use nullish coalescing operator for Prompt API token counts

### DIFF
--- a/prompt-api-playground/script.js
+++ b/prompt-api-playground/script.js
@@ -105,15 +105,15 @@ const SYSTEM_PROMPT = "You are a helpful and friendly assistant.";
     // `session.tokensSoFar` was removed, but the value can be calculated by subtracting
     // `inputUsage` from `inputQuota`. All APIs shapes are checked in the code below.
     maxTokensInfo.textContent = numberFormat.format(
-      session.contextWindow || session.inputQuota || session.maxTokens,
+      session.contextWindow ?? session.inputQuota ?? session.maxTokens,
     );
     tokensLeftInfo.textContent = numberFormat.format(
-      session.tokensSoFar ||
-        session.contextWindow - session.contextUsage ||
+      session.tokensSoFar ??
+        session.contextWindow - session.contextUsage ??
         session.inputQuota - session.inputUsage,
     );
     tokensSoFarInfo.textContent = numberFormat.format(
-      session.contextUsage || session.inputUsage || session.tokensSoFar,
+      session.contextUsage ?? session.inputUsage ?? session.tokensSoFar,
     );
   };
 


### PR DESCRIPTION
Using `||` is falling through if the value is present but zero, which is not the behavior we want, meaning a value that should render as `0` is rendering as `NaN` instead.

This is a minor issue which doesn't really repro in Chrome (I think it's probably adding a system prompt) but in my local testing where token usage starts at zero I've been seeing `NaN` instead.