### PR TITLE
Built-in extension: Remove unneeded permission

### DIFF
--- a/built-in-ai-extension/public/manifest.json
+++ b/built-in-ai-extension/public/manifest.json
@@ -1,9 +1,9 @@
 {
   "manifest_version": 3,
   "name": "Built-in AI",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "Polyfills for the built-in AI APIs like LanguageModel, Summarizer, and Writer.",
-  "permissions": ["storage", "offscreen", "tabs"],
+  "permissions": ["storage", "offscreen"],
   "content_security_policy": {
     "extension_pages": "script-src 'self' 'wasm-unsafe-eval'; object-src 'self';"
   },


### PR DESCRIPTION
`"tabs"` is not needed.