### PR TITLE
Add evals report server + Document how to run + Fix stability calculation

### DIFF
--- a/evals-course/README.md
+++ b/evals-course/README.md
@@ -103,6 +103,22 @@ You can append `-fast` to any script to run in **fast mode** (e.g., `npm run tes
 
 Fast mode caps evaluation scenarios to a small number of samples per suite. Recommended for rapid local iteration and debugging to avoid long wait times.
 
+## Evals Dashboard UI & Reports
+
+Every time you run `npm run test:unit-evals` (or `npm run test:unit-evals-fast`), the evaluation suite generates a detailed HTML report and updates the multi-run dashboard index at `evals-service/reports`.
+
+### Viewing the Dashboard
+
+1. **Automatic Startup**: The test runner automatically attempts to serve the dashboard upon completion on port **8085**:
+   ```
+   🌐 Live Dashboard served at: http://localhost:8085
+   ```
+
+2. **Manual Startup**: If you want to start the dashboard server manually without running the tests again, run the following command from the `evals-service` directory:
+   ```bash
+   npx http-server reports -p 8085
+   ```
+   Then open your browser at [http://localhost:8085](http://localhost:8085).
 
 
 ## Running the eval service

--- a/evals-course/evals-service/src/eval.service.ts
+++ b/evals-course/evals-service/src/eval.service.ts
@@ -150,6 +150,8 @@ export async function evalAll(items: TestCaseInput[], options?: EvalOptions): Pr
     const modelVersion = process.env.JUDGE_MODEL || JUDGE_MODEL;
     const iterations = options?.iterations || EVALS_ITERATION_COUNT_DEFAULT;
 
+    const pad = (num: number, size: number) => num.toString().padStart(size, "0");
+
     for (let i = 0; i < items.length; i++) {
         const item = items[i];
         const id = item.id;
@@ -158,6 +160,13 @@ export async function evalAll(items: TestCaseInput[], options?: EvalOptions): Pr
 
         const expectedOutcome = item.expectedOutcome || ExpectedOutcome.SUCCESS;
 
+        // Construct stable keyed mapping of appOutputs
+        const appOutputsMap: Record<string, AppOutput> = {};
+        for (let idx = 0; idx < appOutputs.length; idx++) {
+            const key = `output-${pad(idx + 1, 3)}`;
+            appOutputsMap[key] = appOutputs[idx];
+        }
+
         const appGateResults: EvalResult[] = [];
         const dataFormatResults: EvalResult[] = [];
         const contrastResults: EvalResult[] = [];
@@ -165,15 +174,17 @@ export async function evalAll(items: TestCaseInput[], options?: EvalOptions): Pr
         const colorBrandFitResults: EvalResult[] = [];
         const mottoBrandFitResults: EvalResult[] = [];
 
-        // Aggregate results helper function
+        // Aggregate results helper function producing Record<string, EvalResult>
         const aggregateResult = (resList: EvalResult[]): MetricResult => {
-            const validResults = resList.filter(r => r.label !== EvalLabel.ERROR);
+            const validResults = resList.filter(r => r.label !== EvalLabel.ERROR && r.label !== EvalLabel.SKIPPED);
             const errorResults = resList.filter(r => r.label === EvalLabel.ERROR);
+            const skippedResults = resList.filter(r => r.label === EvalLabel.SKIPPED);
 
             const passCount = validResults.filter(r => r.label === EvalLabel.PASS).length;
             const errorCount = errorResults.length;
+            const skippedCount = skippedResults.length;
 
-            const denominator = iterations - errorCount;
+            const denominator = iterations - errorCount - skippedCount;
 
             let stabilityRate = 0;
             let label = EvalLabel.FAIL;
@@ -181,6 +192,8 @@ export async function evalAll(items: TestCaseInput[], options?: EvalOptions): Pr
             if (denominator > 0) {
                 stabilityRate = passCount / denominator;
                 label = stabilityRate >= EVALS_STABILITY_THRESHOLD ? EvalLabel.PASS : EvalLabel.FAIL;
+            } else if (skippedCount > 0) {
+                label = EvalLabel.SKIPPED;
             } else {
                 label = EvalLabel.ERROR;
             }
@@ -197,6 +210,8 @@ export async function evalAll(items: TestCaseInput[], options?: EvalOptions): Pr
             let rationaleText = "";
             if (label === EvalLabel.ERROR) {
                 rationaleText = `All iterations errored out. Details:\n${failingRationales.join("\n")}`;
+            } else if (label === EvalLabel.SKIPPED) {
+                rationaleText = "Skipped (App gate triggered)";
             } else {
                 const errorsNote = errorCount > 0 ? ` (Ignored ${errorCount} API errors)` : '';
                 const issueDetails = failingRationales.length > 0
@@ -206,11 +221,17 @@ export async function evalAll(items: TestCaseInput[], options?: EvalOptions): Pr
                 rationaleText = `Stability: ${(stabilityRate * 100).toFixed(0)}% (${passCount}/${denominator})${errorsNote}${issueDetails}`;
             }
 
+            const evalResultsRecord: Record<string, EvalResult> = {};
+            resList.forEach((r, idx) => {
+                const key = `output-${pad(idx + 1, 3)}`;
+                evalResultsRecord[key] = r;
+            });
+
             return {
                 label,
                 rationale: rationaleText,
                 stabilityRate: denominator > 0 ? stabilityRate : undefined,
-                evalResults: resList
+                evalResults: evalResultsRecord
             };
         };
 
@@ -226,35 +247,31 @@ export async function evalAll(items: TestCaseInput[], options?: EvalOptions): Pr
                 if (errorCode === expectedOutcome) {
                     currentAppGateRes = {
                         label: EvalLabel.PASS,
-                        rationale: `Successfully triggered expected blocker: ${errorCode}`,
-                        appOutput: currentOutput
+                        rationale: `Successfully triggered expected blocker: ${errorCode}`
                     };
                 } else {
                     currentAppGateRes = {
                         label: EvalLabel.FAIL,
-                        rationale: `Unexpected block code: ${errorCode} (expected ${expectedOutcome})`,
-                        appOutput: currentOutput
+                        rationale: `Unexpected block code: ${errorCode} (expected ${expectedOutcome})`
                     };
                 }
             } else {
                 if (expectedOutcome !== ExpectedOutcome.SUCCESS) {
                     currentAppGateRes = {
                         label: EvalLabel.FAIL,
-                        rationale: `Failed to block request. Allowed input through (expected ${expectedOutcome})`,
-                        appOutput: currentOutput
+                        rationale: `Failed to block request. Allowed input through (expected ${expectedOutcome})`
                     };
                 } else {
                     currentAppGateRes = {
                         label: EvalLabel.PASS,
-                        rationale: "NONE",
-                        appOutput: currentOutput
+                        rationale: "NONE"
                     };
                 }
             }
             appGateResults.push(currentAppGateRes);
 
             if (isBlocked) {
-                const skipResult: EvalResult = { label: EvalLabel.SKIPPED, rationale: "Skipped due to app gate trigger.", appOutput: currentOutput };
+                const skipResult: EvalResult = { label: EvalLabel.SKIPPED, rationale: "Skipped due to app gate trigger." };
                 dataFormatResults.push(skipResult);
                 contrastResults.push(skipResult);
                 mottoToxicityResults.push(skipResult);
@@ -263,27 +280,27 @@ export async function evalAll(items: TestCaseInput[], options?: EvalOptions): Pr
             } else {
                 // 2. Rule-based Data Format Check
                 const formatRes = evalDataFormat(currentOutput);
-                dataFormatResults.push({ ...formatRes, appOutput: currentOutput });
+                dataFormatResults.push(formatRes);
 
                 // 3. Rule-based Contrast Check
                 const colorPalette = currentOutput.colorPalette;
                 const contrastRes = colorPalette
                     ? evalContrastRatio(colorPalette, CONTRAST_RATIO_MIN)
                     : { label: EvalLabel.FAIL, rationale: "Missing color palette." };
-                contrastResults.push({ ...contrastRes, appOutput: currentOutput });
+                contrastResults.push(contrastRes);
 
                 // 4. LLM-based Brand Fit & Toxicity (evaluates single iteration's current output once)
                 const { mottoToxicity, colorBrandFit, mottoBrandFit } = await evalBrandFitAndToxicity(modelVersion, id, userInput, currentOutput);
-                mottoToxicityResults.push({ ...mottoToxicity, appOutput: currentOutput });
-                colorBrandFitResults.push({ ...colorBrandFit, appOutput: currentOutput });
-                mottoBrandFitResults.push({ ...mottoBrandFit, appOutput: currentOutput });
+                mottoToxicityResults.push(mottoToxicity);
+                colorBrandFitResults.push(colorBrandFit);
+                mottoBrandFitResults.push(mottoBrandFit);
             }
         }
 
         results.push({
             id,
             userInput,
-            appOutputs,
+            appOutputs: appOutputsMap,
             expectedOutcome,
             appGateResult: aggregateResult(appGateResults),
             dataFormat: aggregateResult(dataFormatResults),
@@ -299,9 +316,11 @@ export async function evalAll(items: TestCaseInput[], options?: EvalOptions): Pr
     }
 
     return {
-        results,
-        modelVersion,
-        judgeVersion: loadedJudgeVersion,
+        testCaseResults: results,
+        judgeMetadata: {
+            modelVersion,
+            judgeVersion: loadedJudgeVersion
+        },
         appMetadata: options?.appMetadata
     };
 }

--- a/evals-course/evals-service/src/routes.ts
+++ b/evals-course/evals-service/src/routes.ts
@@ -10,7 +10,7 @@ export const router = Router();
 
 router.post('/evaluate', async (req: Request, res: Response) => {
     try {
-        const { data } = req.body;
+        const { data, appMetadata } = req.body;
         if (!data) {
             res.status(400).json({ error: 'Data payload is required' });
             return;
@@ -18,7 +18,7 @@ router.post('/evaluate', async (req: Request, res: Response) => {
 
         // Ensure data is always an array
         const itemsToEvaluate = Array.isArray(data) ? data : [data];
-        const evaluationResults = await evalAll(itemsToEvaluate);
+        const evaluationResults = await evalAll(itemsToEvaluate, { appMetadata });
         res.json(evaluationResults);
     } catch (error: any) {
         console.error("Evaluation failed:", error);

--- a/evals-course/evals-service/src/types.ts
+++ b/evals-course/evals-service/src/types.ts
@@ -72,20 +72,19 @@ export interface TestCaseInput {
 export interface EvalResult {
     label: EvalLabel;
     rationale?: string;
-    appOutput?: AppOutput;
 }
 
 export interface MetricResult {
     label: EvalLabel;
     rationale?: string;
     stabilityRate?: number;
-    evalResults?: EvalResult[];
+    evalResults?: Record<string, EvalResult>;
 }
 
 export interface TestCaseResult {
     id: string;
     userInput: UserInput;
-    appOutputs: AppOutput[];
+    appOutputs: Record<string, AppOutput>;
     expectedOutcome: ExpectedOutcome;
     appGateResult: MetricResult;
     dataFormat: MetricResult;
@@ -103,6 +102,11 @@ export interface AppMetadata {
     thinkingLevel?: string;
 }
 
+export interface JudgeMetadata {
+    modelVersion: string;
+    judgeVersion: string;
+}
+
 export interface EvalOptions {
     onProgress?: (index: number, total: number) => void;
     iterations?: number;
@@ -110,9 +114,8 @@ export interface EvalOptions {
 }
 
 export interface EvalResponse {
-    results: TestCaseResult[];
-    modelVersion: string;
-    judgeVersion: string;
+    testCaseResults: TestCaseResult[];
+    judgeMetadata: JudgeMetadata;
     appMetadata?: AppMetadata;
 }
 

--- a/evals-course/evals-service/src/utils.reporter.ts
+++ b/evals-course/evals-service/src/utils.reporter.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import * as crypto from 'crypto';
-import { EvalResponse, TestCaseResult, EvalLabel, MetricResult, EvalResult } from './types';
+import { EvalResponse, TestCaseResult, EvalLabel, MetricResult, EvalResult, ExpectedOutcome } from './types';
 import { EVALS_STABILITY_THRESHOLD } from './app.config';
 
 /**
@@ -30,23 +30,23 @@ export function generateHtmlReport(response: EvalResponse, outputDir: string): s
     const outputPath = path.join(outputDir, filename);
 
     // Calculate Summary Stats
-    const totalTests = response.results.length;
-    const iterationsCount = response.results.find(r => r.mottoBrandFit?.evalResults)?.mottoBrandFit?.evalResults?.length ?? 5;
+    const totalTests = response.testCaseResults.length;
+    const iterationsCount = response.testCaseResults.find(r => r.mottoBrandFit?.evalResults)?.mottoBrandFit?.evalResults?.length ?? 5;
     let totalPassedCases = 0;
     let totalEvalsCount = 0;
     let passedEvalsCount = 0;
 
-    response.results.forEach(res => {
+    response.testCaseResults.forEach(res => {
         const evals = [res.dataFormat, res.contrast, res.mottoBrandFit, res.colorBrandFit, res.mottoToxicity];
-        const isCasePassed = evals.every(e => e.label === EvalLabel.PASS);
+        const isCasePassed = evals.every(e => e.label === EvalLabel.PASS || e.label === EvalLabel.SKIPPED) && res.appGateResult.label === EvalLabel.PASS;
         if (isCasePassed) totalPassedCases++;
 
         evals.forEach(e => {
-            const isSkipped = e.rationale && (
+            const isSkipped = e.label === EvalLabel.SKIPPED || (e.rationale && (
                 e.rationale.includes('SKIPPED') ||
                 e.rationale.includes('Blocked') ||
                 e.rationale.includes('N/A')
-            );
+            ));
 
             // Exclude API Errors and skipped/short-circuited evaluations from accuracy denominators
             if (e.label !== EvalLabel.ERROR && !isSkipped) {
@@ -105,9 +105,9 @@ export function generateHtmlReport(response: EvalResponse, outputDir: string): s
 
 
     // Render Results Rows into specific 4 columns: TEST CASE ID, EXPECTED OUTCOME, ACTUAL OUTCOME, TEST STATUS
-    const rows = response.results.map((res: TestCaseResult) => {
+    const rows = response.testCaseResults.map((res: TestCaseResult) => {
         const evals = [res.dataFormat, res.contrast, res.mottoBrandFit, res.colorBrandFit, res.mottoToxicity];
-        const isCasePassed = evals.every(e => e.label === EvalLabel.PASS) && res.appGateResult.label === EvalLabel.PASS;
+        const isCasePassed = evals.every(e => e.label === EvalLabel.PASS || e.label === EvalLabel.SKIPPED) && res.appGateResult.label === EvalLabel.PASS;
         const hasErrors = evals.some(e => e.label === EvalLabel.ERROR) || res.appGateResult.label === EvalLabel.ERROR;
         const hasFailures = evals.some(e => e.label === EvalLabel.FAIL || e.label === EvalLabel.ERROR) ||
             (res.appGateResult.label === EvalLabel.FAIL || res.appGateResult.label === EvalLabel.ERROR);
@@ -116,18 +116,31 @@ export function generateHtmlReport(response: EvalResponse, outputDir: string): s
 
         const gateResult = res.appGateResult;
         const isGatePass = gateResult.label === EvalLabel.PASS;
-        const gateRationale = gateResult.rationale || 'NONE';
 
+        let gateDescription = '';
         let gateBadgeHtml = '';
+
         if (isGatePass) {
-            if (gateRationale === 'NONE') {
+            if (res.expectedOutcome === ExpectedOutcome.SUCCESS) {
+                gateDescription = 'No app gate triggered, as expected';
                 gateBadgeHtml = `<span class="badge pass" style="background-color: #dcfce7; color: #166534; border: 1px solid #bbf7d0; font-size: 0.7rem; padding: 0.15rem 0.4rem;">PASS</span>`;
             } else {
+                gateDescription = `App gate:  <code class="font-mono" style="font-size: 0.75rem; color: #166534;">${res.expectedOutcome}</code>  triggered as expected`;
                 gateBadgeHtml = `<span class="badge pass" style="background-color: #dcfce7; color: #166534; border: 1px solid #bbf7d0; font-size: 0.7rem; padding: 0.15rem 0.4rem;">PASS</span>`;
             }
         } else {
-            const labelText = gateResult.label === EvalLabel.ERROR ? 'ERROR' : 'FAIL';
-            gateBadgeHtml = `<span class="badge fail" style="font-size: 0.7rem; padding: 0.15rem 0.4rem;">${labelText}</span>`;
+            if (gateResult.label === EvalLabel.ERROR) {
+                gateDescription = `App gate error (${escapeHtml(gateResult.rationale || 'Execution failed')})`;
+                gateBadgeHtml = `<span class="badge fail" style="font-size: 0.7rem; padding: 0.15rem 0.4rem;">ERROR</span>`;
+            } else {
+                if (res.expectedOutcome === ExpectedOutcome.SUCCESS) {
+                    gateDescription = `<span style="color: #b91c1c; font-weight: 600;">App gate mistakenly triggered</span>`;
+                    gateBadgeHtml = `<span class="badge fail" style="font-size: 0.7rem; padding: 0.15rem 0.4rem;">FAIL</span>`;
+                } else {
+                    gateDescription = `<span style="color: #b91c1c; font-weight: 600;">App gate failed to trigger</span>`;
+                    gateBadgeHtml = `<span class="badge fail" style="font-size: 0.7rem; padding: 0.15rem 0.4rem;">FAIL</span>`;
+                }
+            }
         }
 
         const overallStatusBadge = isCasePassed
@@ -139,7 +152,7 @@ export function generateHtmlReport(response: EvalResponse, outputDir: string): s
             : (`App gate: ${res.expectedOutcome || 'SUCCESS'}`);
 
         // Tab navigation buttons
-        const totalIterCount = res.appOutputs.length;
+        const totalIterCount = Object.keys(res.appOutputs).length;
         let tabsButtonsHtml = `
             <div class="case-tabs-header">
                 <button class="case-tab-btn tab-btn-${res.id} active" id="btn-${res.id}-summary" onclick="selectCaseTab('${res.id}', 'summary')">
@@ -159,7 +172,7 @@ export function generateHtmlReport(response: EvalResponse, outputDir: string): s
         const summaryContentHtml = `
             <div class="case-tab-content tab-content-${res.id}" id="content-${res.id}-summary" style="display: block;">
                 <div class="vertical-outcome-list">
-                    <div class="outcome-item"><span class="outcome-lbl">App gate:</span> ${gateBadgeHtml}</div>
+                    <div class="outcome-item"><span class="outcome-lbl">App gate:</span> ${gateBadgeHtml}: ${gateDescription} </div>
                     <div class="outcome-item"><span class="outcome-lbl">Data format:</span> ${renderBadge(res.dataFormat)}</div>
                     <div class="outcome-item"><span class="outcome-lbl">Contrast ratio:</span> ${renderBadge(res.contrast)}</div>
                     <div class="outcome-item"><span class="outcome-lbl">Motto brand fit:</span> ${renderBadge(res.mottoBrandFit, true)}</div>
@@ -172,7 +185,8 @@ export function generateHtmlReport(response: EvalResponse, outputDir: string): s
         // Tab Content: Indiv Iterations
         let iterContentsHtml = '';
         for (let j = 0; j < totalIterCount; j++) {
-            const out = res.appOutputs[j] || res.appOutputs[0] || { success: false, errorCode: "NO_OUTPUT" };
+            const key = `output-${(j + 1).toString().padStart(3, '0')}`;
+            const out = res.appOutputs[key] || Object.values(res.appOutputs)[0] || { success: false, errorCode: "NO_OUTPUT" };
             const isBlocked = out.success === false || out.errorCode !== undefined;
 
             iterContentsHtml += `
@@ -245,27 +259,27 @@ export function generateHtmlReport(response: EvalResponse, outputDir: string): s
                     ">
                         <div class="mini-eval-item" style="font-size: 0.7rem; display: flex; align-items: center; justify-content: space-between;">
                             <span class="mini-eval-lbl" style="color: var(--text-muted); font-weight: 500;">App Gate check:</span>
-                            ${renderIterBadge(res.appGateResult.evalResults?.[j])}
+                            ${renderIterBadge(res.appGateResult.evalResults?.[key])}
                         </div>
                         <div class="mini-eval-item" style="font-size: 0.7rem; display: flex; align-items: center; justify-content: space-between; border-bottom: 1px dashed #e2e8f0; padding-bottom: 2px;">
                             <span class="mini-eval-lbl" style="color: var(--text-muted); font-weight: 500;">Data format check:</span>
-                            ${renderIterBadge(res.dataFormat.evalResults?.[j])}
+                            ${renderIterBadge(res.dataFormat.evalResults?.[key])}
                         </div>
                         <div class="mini-eval-item" style="font-size: 0.7rem; display: flex; align-items: center; justify-content: space-between; border-bottom: 1px dashed #e2e8f0; padding-bottom: 2px;">
                             <span class="mini-eval-lbl" style="color: var(--text-muted); font-weight: 500;">Contrast ratio:</span>
-                            ${renderIterBadge(res.contrast.evalResults?.[j])}
+                            ${renderIterBadge(res.contrast.evalResults?.[key])}
                         </div>
                         <div class="mini-eval-item" style="font-size: 0.7rem; display: flex; align-items: center; justify-content: space-between; border-bottom: 1px dashed #e2e8f0; padding-bottom: 2px;">
                             <span class="mini-eval-lbl" style="color: var(--text-muted); font-weight: 500;">Motto brand fit:</span>
-                            ${renderIterBadge(res.mottoBrandFit.evalResults?.[j])}
+                            ${renderIterBadge(res.mottoBrandFit.evalResults?.[key])}
                         </div>
                         <div class="mini-eval-item" style="font-size: 0.7rem; display: flex; align-items: center; justify-content: space-between; border-bottom: 1px dashed #e2e8f0; padding-bottom: 2px;">
                             <span class="mini-eval-lbl" style="color: var(--text-muted); font-weight: 500;">Color brand fit:</span>
-                            ${renderIterBadge(res.colorBrandFit.evalResults?.[j])}
+                            ${renderIterBadge(res.colorBrandFit.evalResults?.[key])}
                         </div>
                         <div class="mini-eval-item" style="font-size: 0.7rem; display: flex; align-items: center; justify-content: space-between;">
                             <span class="mini-eval-lbl" style="color: var(--text-muted); font-weight: 500;">Motto toxicity:</span>
-                            ${renderIterBadge(res.mottoToxicity.evalResults?.[j])}
+                            ${renderIterBadge(res.mottoToxicity.evalResults?.[key])}
                         </div>
                     </div>
                 </div>
@@ -683,7 +697,7 @@ export function generateHtmlReport(response: EvalResponse, outputDir: string): s
             <div>
                 <a href="index.html" class="back-link">← All reports</a>
                 <h1 style="text-transform: none;">Evaluation report</h1>
-                <div class="timestamp">Generated at: ${humanTimestamp} | Judge system: <code>v${response.judgeVersion ?? '1.0'}</code> | Model: <code>${response.modelVersion ?? 'N/A'}</code></div>
+                <div class="timestamp">Generated at: ${humanTimestamp} | Judge system: <code>v${response.judgeMetadata?.judgeVersion ?? '1.0'}</code> | Model: <code>${response.judgeMetadata?.modelVersion ?? 'N/A'}</code></div>
             </div>
         </header>
 
@@ -806,12 +820,12 @@ function renderIterBadge(evalRes?: EvalResult): string {
         return `<span class="badge skipped" style="background-color: #edf2f7; color: #4a5568; border: 1px solid #cbd5e1; font-size: 0.65rem; padding: 1px 4px;">N/A</span>`;
     }
 
-    const isSkipped = evalRes.rationale && (
+    const isSkipped = evalRes.label === EvalLabel.SKIPPED || (evalRes.rationale && (
         evalRes.rationale.includes('Blocked in front') ||
         evalRes.rationale.includes('N/A') ||
         evalRes.rationale.includes('Security gate triggered') ||
         evalRes.rationale.toLowerCase().includes('skipped')
-    );
+    ));
 
     if (isSkipped) {
         return `<span class="badge skipped" style="background-color: #edf2f7; color: #4a5568; border: 1px solid #cbd5e1; font-size: 0.65rem; padding: 1px 4px;">SKIPPED</span>`;
@@ -832,12 +846,12 @@ function renderBadge(result: MetricResult, showStability = false): string {
     }
 
     // Check if this was short-circuited/skipped due to front-end refusal/safety blocking
-    const isSkipped = result.rationale && (
+    const isSkipped = result.label === EvalLabel.SKIPPED || (result.rationale && (
         result.rationale.includes('Blocked in front') ||
         result.rationale.includes('N/A') ||
         result.rationale.includes('Security gate triggered') ||
         result.rationale.toLowerCase().includes('skipped')
-    );
+    ));
     if (isSkipped) {
         return `<span class="badge skipped" style="background-color: #edf2f7; color: #4a5568; border: 1px solid #cbd5e1; font-size: 0.7rem;">SKIPPED</span>`;
     }
@@ -852,8 +866,9 @@ function renderBadge(result: MetricResult, showStability = false): string {
         if (result.stabilityRate !== undefined) {
             stabilityText = `<span class="stability-tag">${(result.stabilityRate * 100).toFixed(0)}%</span>`;
         }
-        if (result.evalResults && result.evalResults.length > 0) {
-            const dots = result.evalResults.map((iter: any, idx: number) => {
+        const evalResultsVal = result.evalResults ? Object.values(result.evalResults) : [];
+        if (evalResultsVal.length > 0) {
+            const dots = evalResultsVal.map((iter: EvalResult, idx: number) => {
                 const title = `Iteration ${idx + 1}: ${iter.label}${iter.rationale ? ` - ${escapeHtml(iter.rationale)}` : ''}`;
                 if (iter.label === EvalLabel.PASS) return `<span class="iter-dot pass" title="${title}">P</span>`;
                 if (iter.label === EvalLabel.FAIL) return `<span class="iter-dot fail" title="${title}">F</span>`;

--- a/evals-course/evals-service/test/test.llm-judge-alignment-basic.ts
+++ b/evals-course/evals-service/test/test.llm-judge-alignment-basic.ts
@@ -49,7 +49,7 @@ async function run() {
     onProgress: (current, total) => logProgress(startTime, current, total)
   });
   const { mismatches, totalSampleCount, alignedSampleCount } =
-    computeBasicAlignmentStats(evalResponse.results, humanLabelsMap);
+    computeBasicAlignmentStats(evalResponse.testCaseResults, humanLabelsMap);
   logMismatches(mismatches);
   const alignment = calculatePercentage(alignedSampleCount, totalSampleCount);
 

--- a/evals-course/evals-service/test/test.llm-judge-alignment-bootstrap-basic.ts
+++ b/evals-course/evals-service/test/test.llm-judge-alignment-bootstrap-basic.ts
@@ -103,7 +103,7 @@ async function run() {
     onProgress: (current, total) => logProgress(startTime, current, total)
   });
   const llmResultsMap = new Map();
-  for (const result of allEvalResults.results) {
+  for (const result of allEvalResults.testCaseResults) {
     llmResultsMap.set(result.id, result);
   }
 

--- a/evals-course/evals-service/test/test.llm-judge-alignment-bootstrap.ts
+++ b/evals-course/evals-service/test/test.llm-judge-alignment-bootstrap.ts
@@ -108,7 +108,7 @@ async function run() {
     onProgress: (current, total) => logProgress(startTime, current, total)
   });
   const llmResultsMap = new Map();
-  for (const result of allEvalResults.results) {
+  for (const result of allEvalResults.testCaseResults) {
     llmResultsMap.set(result.id, result);
   }
 

--- a/evals-course/evals-service/test/test.llm-judge-alignment.ts
+++ b/evals-course/evals-service/test/test.llm-judge-alignment.ts
@@ -48,7 +48,7 @@ async function run() {
     onProgress: (current, total) => logProgress(startTime, current, total)
   });
   const { rawStatsAllMetrics, mismatches, total, aligned } =
-    computeAlignmentStats(evalResponse.results, humanLabelsMap);
+    computeAlignmentStats(evalResponse.testCaseResults, humanLabelsMap);
   logMismatches(mismatches);
   const finalResults = calculateFinalAlignmentResults(rawStatsAllMetrics, total, aligned);
   logFinalResults(sampleCount, finalResults);

--- a/evals-course/evals-service/test/test.llm-judge-consistency.ts
+++ b/evals-course/evals-service/test/test.llm-judge-consistency.ts
@@ -97,8 +97,8 @@ async function run() {
     }));
 
     responses.forEach((response, index) => {
-      if (response.results && response.results.length > 0) {
-        const res = response.results[0];
+      if (response.testCaseResults && response.testCaseResults.length > 0) {
+        const res = response.testCaseResults[0];
         const tcId = testCases[index].id;
         const mapped = rawResultsMap.get(tcId)!;
         mapped.mottoToxicity.push(res.mottoToxicity.label);

--- a/evals-course/evals-service/test/test.rule-contrast.ts
+++ b/evals-course/evals-service/test/test.rule-contrast.ts
@@ -5,7 +5,7 @@
 
 import dotenv from 'dotenv';
 dotenv.config({ quiet: true });
-import { evalContrastRatio } from '../src/eval.service';
+import { evalContrastRatio } from '../src/utils.evals';
 import { EvalLabel } from '../src/types';
 import { CONTRAST_RATIO_MIN } from '../src/app.config';
 import { TEST_SAMPLE_COUNT_FAST_DEBUG } from './test.config';

--- a/evals-course/evals-service/test/test.rule-format.ts
+++ b/evals-course/evals-service/test/test.rule-format.ts
@@ -6,7 +6,7 @@
 import dotenv from 'dotenv';
 dotenv.config({ quiet: true });
 
-import { evalDataFormat } from '../src/eval.service';
+import { evalDataFormat } from '../src/utils.evals';
 import { EvalLabel, AppOutput, ColorPalette } from '../src/types';
 import { TEST_SAMPLE_COUNT_FAST_DEBUG } from './test.config';
 

--- a/evals-course/evals-service/test/test.unit.ts
+++ b/evals-course/evals-service/test/test.unit.ts
@@ -7,6 +7,7 @@ import * as dotenv from 'dotenv';
 dotenv.config({ quiet: true });
 import * as fs from 'fs';
 import * as path from 'path';
+import { exec } from 'child_process';
 import { evalAll, loadedJudgeVersion } from '../src/eval.service';
 import { EvalLabel, TestCaseResult, EvalResponse, MetricResult, EvalResult, ExpectedOutcome, TestCase } from '../src/types';
 import { themeBuilder, THEME_BUILDER_SYSTEM_INSTRUCTION, THEME_BUILDER_PROMPT_TEMPLATE } from '../../theme-builder/theme-builder';
@@ -85,7 +86,7 @@ async function runUnitTests() {
          );
          stopJudgeSpinner();
 
-         const res = evalResponse.results[0];
+         const res = evalResponse.testCaseResults[0];
          allEvalResults.push(res);
 
          // Print results per metric
@@ -107,7 +108,7 @@ async function runUnitTests() {
          const logMetric = (name: string, result: MetricResult, showDetails = false) => {
             const label = result.label;
             const details = showDetails && result.stabilityRate !== undefined
-               ? ` (Stability: ${(result.stabilityRate * 100).toFixed(0)}% | Iterations: [${result.evalResults?.map(it => (it as any).label).join(', ')}])`
+               ? ` (Stability: ${(result.stabilityRate * 100).toFixed(0)}% | Iterations: [${Object.values(result.evalResults || {}).map(it => it.label).join(', ')}])`
                : '';
             if (label === EvalLabel.PASS) {
                console.log(`  ${name}: \x1b[32mPASS\x1b[0m${details}`);
@@ -135,13 +136,13 @@ async function runUnitTests() {
             id: testCase.id,
             userInput: testCase.userInput,
             expectedOutcome: testCase.expected,
-            appOutputs: [],
+            appOutputs: {},
             appGateResult: { label: EvalLabel.FAIL, rationale: `Runner crashed: ${e.message}` },
-            dataFormat: { label: EvalLabel.FAIL, rationale: `Crashed during execution: ${e.message}`, stabilityRate: 0, evalResults: [] },
-            colorBrandFit: { label: EvalLabel.FAIL, rationale: "Crashed", stabilityRate: 0, evalResults: [] },
-            contrast: { label: EvalLabel.FAIL, rationale: "Crashed", stabilityRate: 0, evalResults: [] },
-            mottoToxicity: { label: EvalLabel.FAIL, rationale: "Crashed", stabilityRate: 0, evalResults: [] },
-            mottoBrandFit: { label: EvalLabel.FAIL, rationale: "Crashed", stabilityRate: 0, evalResults: [] }
+            dataFormat: { label: EvalLabel.FAIL, rationale: `Crashed during execution: ${e.message}`, stabilityRate: 0, evalResults: {} },
+            colorBrandFit: { label: EvalLabel.FAIL, rationale: "Crashed", stabilityRate: 0, evalResults: {} },
+            contrast: { label: EvalLabel.FAIL, rationale: "Crashed", stabilityRate: 0, evalResults: {} },
+            mottoToxicity: { label: EvalLabel.FAIL, rationale: "Crashed", stabilityRate: 0, evalResults: {} },
+            mottoBrandFit: { label: EvalLabel.FAIL, rationale: "Crashed", stabilityRate: 0, evalResults: {} }
          });
       }
 
@@ -175,9 +176,11 @@ async function runUnitTests() {
    const promptTemplateInfo = THEME_BUILDER_PROMPT_TEMPLATE;
 
    const evalResponseForReport: EvalResponse = {
-      results: allEvalResults,
-      modelVersion: process.env.JUDGE_MODEL || JUDGE_MODEL,
-      judgeVersion: loadedJudgeVersion,
+      testCaseResults: allEvalResults,
+      judgeMetadata: {
+         modelVersion: process.env.JUDGE_MODEL || JUDGE_MODEL,
+         judgeVersion: loadedJudgeVersion,
+      },
       appMetadata: {
          model: process.env.AI_MODEL || APP_MODEL,
          systemInstruction: systemInstructionInfo,
@@ -189,6 +192,20 @@ async function runUnitTests() {
       const reportPath = generateHtmlReport(evalResponseForReport, reportDir);
       console.log(`📊 Evals HTML Report generated at: ${reportPath}`);
       console.log(`🌐 Multi-run dashboard index updated at: ${path.join(reportDir, 'index.html')}`);
+      
+      console.log("\n⚡ Starting local dashboard server automatically...");
+      const serverProcess = exec(`npx -y http-server "${reportDir}" -p 8085`, (err) => {
+         if (err && !err.message.includes("EADDRINUSE")) {
+            console.error(`❌ Failed to start dashboard server: ${err.message}`);
+         }
+      });
+      serverProcess.stdout?.on('data', (data) => {
+         if (data.includes("Available on:")) {
+            console.log(`🌐 Live Dashboard served at: http://localhost:8085`);
+         }
+      });
+      // Unreference the child process to allow Node to exit cleanly
+      serverProcess.unref();
    } catch (reportError: any) {
       console.error(`❌ Failed to generate HTML report: ${reportError.message}`);
    }


### PR DESCRIPTION
`npm run test:unit-evals`

Then run the evals server with `npx http-server reports -p 8085`

Individual report:
<img width="1451" height="957" alt="image" src="https://github.com/user-attachments/assets/fc3bad2e-d50d-4bce-8057-e1c1c8888baf" />

Report list:
<img width="1434" height="936" alt="image" src="https://github.com/user-attachments/assets/09e4e1e2-fb99-45ee-94ef-af390e343173" />


