### PR TITLE
[Builtin AI task APIs polyfills] Add SemanticEmbedder polyfill

### DIFF
--- a/built-in-ai-task-apis-polyfills/README.md
+++ b/built-in-ai-task-apis-polyfills/README.md
@@ -9,12 +9,21 @@ specifically:
 - **Rewriter API**
 - **Language Detector API**
 - **Translator API**
+- **SemanticEmbedder API**
 
-These polyfills are backed by the
+The Summarizer, Writer, Rewriter, Language Detector, and Translator polyfills
+are backed by the
 [`prompt-api-polyfill`](https://github.com/GoogleChromeLabs/web-ai-demos/tree/main/prompt-api-polyfill),
 which is automatically loaded if `window.LanguageModel` is not detected. This
 means they support the same
 [dynamic backends](https://github.com/GoogleChromeLabs/web-ai-demos/tree/main/prompt-api-polyfill#supported-backends).
+
+The SemanticEmbedder polyfill is backed by
+[EmbeddingGemma 300M](https://huggingface.co/onnx-community/embeddinggemma-300m-ONNX)
+— the same model Chrome's built-in SemanticEmbedder API uses on-device — running
+in-browser via
+[`@huggingface/transformers`](https://huggingface.co/docs/transformers.js) (a
+peer dependency you must install separately).
 
 When loaded in the browser, they define globals:
 
@@ -24,6 +33,7 @@ window.Writer;
 window.Rewriter;
 window.LanguageDetector;
 window.Translator;
+window.SemanticEmbedder;
 ```
 
 so you can use these Task APIs even in environments where they are not yet
@@ -35,6 +45,12 @@ Install from npm:
 
 ```bash
 npm install built-in-ai-task-apis-polyfills
+```
+
+If you use the **SemanticEmbedder** polyfill, also install the peer dependency:
+
+```bash
+npm install @huggingface/transformers
 ```
 
 ## Quick start
@@ -67,6 +83,9 @@ defensive dynamic import strategy:
   }
   if (!('Translator' in window)) {
     polyfills.push(import('built-in-ai-task-apis-polyfills/translator'));
+  }
+  if (!('SemanticEmbedder' in window)) {
+    polyfills.push(import('built-in-ai-task-apis-polyfills/semantic-embedder'));
   }
   await Promise.all(polyfills);
 
@@ -145,6 +164,40 @@ const translator = await Translator.create({
 const result = await translator.translate('Hello world');
 ```
 
+#### SemanticEmbedder API
+
+Backed by
+[EmbeddingGemma 300M](https://huggingface.co/onnx-community/embeddinggemma-300m-ONNX)
+via `@huggingface/transformers`. The model (~420 MB) is downloaded and cached in
+the browser on first use.
+
+```js
+const embedder = await SemanticEmbedder.create({
+  monitor(m) {
+    m.addEventListener('downloadprogress', (e) => {
+      console.log(`Download progress: ${Math.round(e.loaded * 100)}%`);
+    });
+  },
+});
+
+// Embed a single text
+const { embeddings } = await embedder.embed('Hello world');
+console.log(embeddings[0].values); // Float32Array of 768 values
+
+// Semantic search: embed query and corpus with appropriate task prefixes
+const [queryResult, docsResult] = await Promise.all([
+  embedder.embed('What is machine learning?', { taskType: 'query' }),
+  embedder.embed(['AI transforms software.', 'Paris is in France.'], {
+    taskType: 'document',
+  }),
+]);
+
+const queryVec = queryResult.embeddings[0].values;
+const scores = docsResult.embeddings.map((e) =>
+  SemanticEmbedder.cosineSimilarity(queryVec, e.values)
+);
+```
+
 ---
 
 ## Configuration
@@ -174,14 +227,16 @@ documentation:
 - [Rewriter API](https://developer.chrome.com/docs/ai/rewriter-api)
 - [Language Detector API](https://developer.chrome.com/docs/ai/language-detection-api)
 - [Translator API](https://developer.chrome.com/docs/ai/translator-api)
+- [SemanticEmbedder API](https://github.com/explainers-by-googlers/embedding-api)
 
 For complete examples, see:
 
-- [`demo_summarizer.html`](demo_summarizer.html)
-- [`demo_writer.html`](demo_writer.html)
-- [`demo_rewriter.html`](demo_rewriter.html)
-- [`demo_language_detector.html`](demo_language_detector.html)
-- [`demo_translator.html`](demo_translator.html)
+- [`demo-summarizer.html`](demo-summarizer.html)
+- [`demo-writer.html`](demo-writer.html)
+- [`demo-rewriter.html`](demo-rewriter.html)
+- [`demo-language-detector.html`](demo-language-detector.html)
+- [`demo-translator.html`](demo-translator.html)
+- [`demo-semantic-embedder.html`](demo-semantic-embedder.html)
 
 ---
 

--- a/built-in-ai-task-apis-polyfills/demo-semantic-embedder.html
+++ b/built-in-ai-task-apis-polyfills/demo-semantic-embedder.html
@@ -1,0 +1,439 @@
+<!--
+  Copyright 2026 Google LLC
+  SPDX-License-Identifier: Apache-2.0
+-->
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>SemanticEmbedder API Polyfill Demo</title>
+    <style>
+      :root {
+        color-scheme: dark light;
+      }
+
+      html {
+        box-sizing: border-box;
+      }
+
+      *,
+      *:before,
+      *:after {
+        box-sizing: inherit;
+      }
+
+      body {
+        font-family: system-ui, sans-serif;
+        max-width: clamp(320px, 90%, 900px);
+        margin: auto;
+        padding-bottom: 2rem;
+      }
+
+      textarea {
+        width: 100%;
+        height: 80px;
+        font-family: inherit;
+        resize: vertical;
+      }
+
+      .corpus-item {
+        display: flex;
+        gap: 0.5rem;
+        align-items: flex-start;
+        margin-bottom: 0.5rem;
+      }
+
+      .corpus-item textarea {
+        flex: 1;
+        height: 60px;
+      }
+
+      .corpus-item button {
+        flex-shrink: 0;
+      }
+
+      button {
+        cursor: pointer;
+        padding: 0.4rem 0.8rem;
+      }
+
+      progress {
+        width: 100%;
+      }
+
+      #status {
+        font-style: italic;
+        color: gray;
+        min-height: 1.4em;
+      }
+
+      .results {
+        border: 1px solid #ccc;
+        padding: 1rem;
+        min-height: 80px;
+      }
+
+      .result-row {
+        display: flex;
+        gap: 1rem;
+        align-items: baseline;
+        padding: 0.4rem 0;
+        border-bottom: 1px solid #eee;
+      }
+
+      .result-row:last-child {
+        border-bottom: none;
+      }
+
+      .result-score {
+        font-weight: bold;
+        font-variant-numeric: tabular-nums;
+        min-width: 5ch;
+        color: #0070f3;
+      }
+
+      .result-text {
+        flex: 1;
+      }
+
+      .similarity-bar {
+        height: 6px;
+        border-radius: 3px;
+        background: #0070f3;
+        transition: width 0.3s ease;
+      }
+
+      .similarity-bar-bg {
+        background: #e5e7eb;
+        border-radius: 3px;
+        overflow: hidden;
+        width: 80px;
+        flex-shrink: 0;
+      }
+
+      .embed-output {
+        font-family: monospace;
+        font-size: 0.85rem;
+        white-space: pre-wrap;
+        word-break: break-all;
+        border: 1px solid #ccc;
+        padding: 0.75rem;
+        min-height: 60px;
+        max-height: 200px;
+        overflow-y: auto;
+      }
+
+      section {
+        margin-top: 2rem;
+      }
+
+      h2 {
+        margin-bottom: 0.5rem;
+      }
+
+      .controls {
+        display: flex;
+        gap: 0.5rem;
+        flex-wrap: wrap;
+        align-items: center;
+        margin-bottom: 0.5rem;
+      }
+    </style>
+  </head>
+
+  <body>
+    <h1>SemanticEmbedder API Polyfill Demo</h1>
+    <p>
+      Demonstrates the proposed
+      <a
+        href="https://github.com/explainers-by-googlers/embedding-api"
+        target="_blank"
+        >SemanticEmbedder API</a
+      >
+      backed by
+      <a
+        href="https://huggingface.co/onnx-community/embeddinggemma-300m-ONNX"
+        target="_blank"
+        >EmbeddingGemma 300M</a
+      >
+      — the same model Chrome's built-in API uses — running in-browser via
+      <code>@huggingface/transformers</code>.
+    </p>
+
+    <progress id="progress" value="0" max="1" style="display: none"></progress>
+    <div id="status"></div>
+    <div class="controls">
+      <span id="availability"></span>
+    </div>
+
+    <!-- Semantic Search Section -->
+    <section>
+      <h2>Semantic Search</h2>
+      <p>
+        Embed a corpus of texts, then find which are most semantically similar
+        to your query.
+      </p>
+
+      <h3>Corpus</h3>
+      <div id="corpus"></div>
+      <div class="controls" style="margin-top: 0.5rem">
+        <input
+          id="addCorpusInput"
+          type="text"
+          placeholder="New sentence…"
+          style="
+            flex: 1;
+            padding: 0.4rem 0.6rem;
+            font-family: inherit;
+            font-size: inherit;
+          "
+        />
+        <button id="addCorpusBtn">Add</button>
+      </div>
+
+      <h3>Query</h3>
+      <textarea id="queryInput" placeholder="Type a query…">
+What is machine learning?</textarea
+      >
+
+      <div class="controls" style="margin-top: 0.5rem">
+        <button id="searchBtn">Find Most Similar</button>
+      </div>
+
+      <h3>Results (ranked by cosine similarity)</h3>
+      <div id="searchResults" class="results">
+        Results will appear here after searching.
+      </div>
+    </section>
+
+    <!-- Single Embed Section -->
+    <section>
+      <h2>Embed a Single Text</h2>
+      <textarea id="singleInput" placeholder="Text to embed…">
+The quick brown fox jumps over the lazy dog.</textarea
+      >
+      <div class="controls" style="margin-top: 0.5rem">
+        <button id="embedBtn">Embed</button>
+      </div>
+      <h3>Embedding Vector (first 16 values)</h3>
+      <div id="embedOutput" class="embed-output">—</div>
+      <p id="embedMeta" style="font-size: 0.85rem; color: gray"></p>
+    </section>
+
+    <script type="module">
+      import { SemanticEmbedder } from './semantic-embedder-api-polyfill.js';
+
+      const searchBtn = document.getElementById('searchBtn');
+      const embedBtn = document.getElementById('embedBtn');
+      const addCorpusBtn = document.getElementById('addCorpusBtn');
+      const addCorpusInput = document.getElementById('addCorpusInput');
+      const queryInput = document.getElementById('queryInput');
+      const singleInput = document.getElementById('singleInput');
+      const searchResults = document.getElementById('searchResults');
+      const embedOutput = document.getElementById('embedOutput');
+      const embedMeta = document.getElementById('embedMeta');
+      const progressEl = document.getElementById('progress');
+      const statusEl = document.getElementById('status');
+      const availabilityEl = document.getElementById('availability');
+      const corpusEl = document.getElementById('corpus');
+
+      const DEFAULT_CORPUS = [
+        'Artificial intelligence is transforming how we build software.',
+        'The cat sat on the mat and looked out the window.',
+        'Deep learning models learn representations from raw data.',
+        'Paris is the capital city of France.',
+        'Neural networks are inspired by the structure of the brain.',
+        'The stock market fell sharply yesterday morning.',
+        'Natural language processing enables machines to understand text.',
+        'She baked a chocolate cake for the birthday party.',
+      ];
+
+      // Build corpus UI
+      function addCorpusRow(text = '') {
+        const row = document.createElement('div');
+        row.className = 'corpus-item';
+        const ta = document.createElement('textarea');
+        ta.value = text;
+        ta.placeholder = 'Corpus sentence…';
+        const removeBtn = document.createElement('button');
+        removeBtn.textContent = '✕';
+        removeBtn.title = 'Remove';
+        removeBtn.onclick = () => row.remove();
+        row.appendChild(ta);
+        row.appendChild(removeBtn);
+        corpusEl.appendChild(row);
+      }
+
+      DEFAULT_CORPUS.forEach((t) => addCorpusRow(t));
+
+      function getCorpusTexts() {
+        return [...corpusEl.querySelectorAll('textarea')]
+          .map((ta) => ta.value.trim())
+          .filter(Boolean);
+      }
+
+      // Reflect the real availability state as soon as the page loads.
+      SemanticEmbedder.availability().then((avail) => {
+        availabilityEl.textContent = `Availability: ${avail}`;
+      });
+
+      let embedder = null;
+      let loadingPromise = null;
+
+      // Lazily loads the model on first use. Subsequent calls return the same
+      // embedder without reloading. Concurrent callers share the same promise.
+      async function ensureEmbedder() {
+        if (embedder) {
+          return embedder;
+        }
+        if (loadingPromise) {
+          return loadingPromise;
+        }
+
+        statusEl.textContent = 'Loading model…';
+        progressEl.style.display = 'block';
+        progressEl.value = 0;
+
+        loadingPromise = SemanticEmbedder.create({
+          monitor(m) {
+            m.addEventListener('downloadprogress', (e) => {
+              availabilityEl.textContent = 'Availability: downloading';
+              progressEl.value = e.loaded;
+              if (e.loaded < 1) {
+                statusEl.textContent = `Downloading model: ${Math.round(e.loaded * 100)}%`;
+              }
+            });
+          },
+        })
+          .then(async (result) => {
+            embedder = result;
+            loadingPromise = null;
+            availabilityEl.textContent = `Availability: ${await SemanticEmbedder.availability()}`;
+            statusEl.textContent = 'Model loaded. Ready to embed.';
+            progressEl.style.display = 'none';
+            return embedder;
+          })
+          .catch((err) => {
+            loadingPromise = null;
+            statusEl.textContent = `Error loading model: ${err.message}`;
+            progressEl.style.display = 'none';
+            throw err;
+          });
+
+        return loadingPromise;
+      }
+
+      addCorpusBtn.onclick = () => {
+        const text = addCorpusInput.value.trim();
+        if (!text) {
+          return;
+        }
+        addCorpusRow(text);
+        addCorpusInput.value = '';
+        addCorpusInput.focus();
+        ensureEmbedder().catch(() => {});
+      };
+
+      searchBtn.onclick = async () => {
+        const query = queryInput.value.trim();
+        const corpus = getCorpusTexts();
+
+        if (!query || corpus.length === 0) {
+          searchResults.textContent =
+            'Please enter a query and at least one corpus sentence.';
+          return;
+        }
+
+        searchBtn.disabled = true;
+        searchResults.textContent = 'Computing embeddings…';
+
+        try {
+          const emb = await ensureEmbedder();
+          statusEl.textContent = 'Embedding…';
+
+          // EmbeddingGemma uses different task prefixes for queries vs documents,
+          // so we embed them with the appropriate taskType in separate calls.
+          const [queryResult, docsResult] = await Promise.all([
+            emb.embed(query, { taskType: 'query' }),
+            emb.embed(corpus, { taskType: 'document' }),
+          ]);
+
+          const queryVec = queryResult.embeddings[0].values;
+          const scored = corpus.map((text, i) => ({
+            text,
+            score: SemanticEmbedder.cosineSimilarity(
+              queryVec,
+              docsResult.embeddings[i].values
+            ),
+          }));
+          scored.sort((a, b) => b.score - a.score);
+
+          searchResults.innerHTML = '';
+          for (const { text, score } of scored) {
+            const row = document.createElement('div');
+            row.className = 'result-row';
+
+            const scoreEl = document.createElement('span');
+            scoreEl.className = 'result-score';
+            scoreEl.textContent = score.toFixed(3);
+
+            const barBg = document.createElement('div');
+            barBg.className = 'similarity-bar-bg';
+            const bar = document.createElement('div');
+            bar.className = 'similarity-bar';
+            bar.style.width = `${Math.max(0, score * 100).toFixed(1)}%`;
+            barBg.appendChild(bar);
+
+            const textEl = document.createElement('span');
+            textEl.className = 'result-text';
+            textEl.textContent = text;
+
+            row.appendChild(scoreEl);
+            row.appendChild(barBg);
+            row.appendChild(textEl);
+            searchResults.appendChild(row);
+          }
+
+          statusEl.textContent = `Done. Embedded query + ${corpus.length} documents (embedding space: ${docsResult.metadata.embeddingSpace}).`;
+        } catch (err) {
+          searchResults.textContent = `Error: ${err.message}`;
+          statusEl.textContent = 'Embedding failed.';
+        } finally {
+          searchBtn.disabled = false;
+        }
+      };
+
+      embedBtn.onclick = async () => {
+        const text = singleInput.value.trim();
+        if (!text) {
+          embedOutput.textContent = 'Please enter some text.';
+          return;
+        }
+
+        embedBtn.disabled = true;
+        embedOutput.textContent = 'Computing embedding…';
+
+        try {
+          const emb = await ensureEmbedder();
+          statusEl.textContent = 'Embedding…';
+
+          const result = await emb.embed(text);
+          const values = result.embeddings[0].values;
+
+          const preview = Array.from(values.slice(0, 16))
+            .map((v) => v.toFixed(6))
+            .join(', ');
+          embedOutput.textContent = `[${preview}, … (${values.length} total)]`;
+          embedMeta.textContent = `Embedding space: ${result.metadata.embeddingSpace} | Max input tokens: ${result.metadata.maxInputTokens} | Dimensions: ${values.length}`;
+          statusEl.textContent = 'Embedding complete.';
+        } catch (err) {
+          embedOutput.textContent = `Error: ${err.message}`;
+          statusEl.textContent = 'Embedding failed.';
+        } finally {
+          embedBtn.disabled = false;
+        }
+      };
+    </script>
+  </body>
+</html>

--- a/built-in-ai-task-apis-polyfills/index.js
+++ b/built-in-ai-task-apis-polyfills/index.js
@@ -9,6 +9,7 @@ import './rewriter-api-polyfill.js';
 import './language-detector-api-polyfill.js';
 import './translator-api-polyfill.js';
 // import './classifier-api-polyfill.js';
+import './semantic-embedder-api-polyfill.js';
 
 export { Summarizer } from './summarizer-api-polyfill.js';
 export { Writer } from './writer-api-polyfill.js';
@@ -16,3 +17,4 @@ export { Rewriter } from './rewriter-api-polyfill.js';
 export { LanguageDetector } from './language-detector-api-polyfill.js';
 export { Translator } from './translator-api-polyfill.js';
 // export { Classifier } from './classifier-api-polyfill.js';
+export { SemanticEmbedder } from './semantic-embedder-api-polyfill.js';

--- a/built-in-ai-task-apis-polyfills/package-lock.json
+++ b/built-in-ai-task-apis-polyfills/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.12.0",
       "license": "Apache-2.0",
       "dependencies": {
+        "@huggingface/transformers": "^4.2.0",
         "prompt-api-polyfill": "^1.19.0"
       },
       "devDependencies": {

--- a/built-in-ai-task-apis-polyfills/package.json
+++ b/built-in-ai-task-apis-polyfills/package.json
@@ -1,6 +1,6 @@
 {
   "name": "built-in-ai-task-apis-polyfills",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "description": "Polyfills for the Built-in AI Task APIs (Summarizer, Writer, Rewriter, etc.)",
   "type": "module",
   "main": "./dist/index.js",

--- a/built-in-ai-task-apis-polyfills/package.json
+++ b/built-in-ai-task-apis-polyfills/package.json
@@ -11,7 +11,8 @@
     "./rewriter": "./dist/rewriter.js",
     "./language-detector": "./dist/language-detector.js",
     "./translator": "./dist/translator.js",
-    "./classifier": "./dist/classifier.js"
+    "./classifier": "./dist/classifier.js",
+    "./semantic-embedder": "./dist/semantic-embedder.js"
   },
   "files": [
     "dist/",
@@ -50,12 +51,22 @@
     "translator",
     "language-detector",
     "classifier",
+    "semantic-embedder",
+    "embeddings",
     "web-ai"
   ],
   "homepage": "https://github.com/GoogleChromeLabs/web-ai-demos/tree/main/built-in-ai-task-apis-polyfills#readme",
   "bugs": "https://github.com/GoogleChromeLabs/web-ai-demos/issues",
   "dependencies": {
     "prompt-api-polyfill": "^1.19.0"
+  },
+  "peerDependencies": {
+    "@huggingface/transformers": ">=4.2.0"
+  },
+  "peerDependenciesMeta": {
+    "@huggingface/transformers": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/built-in-ai-task-apis-polyfills/semantic-embedder-api-polyfill.js
+++ b/built-in-ai-task-apis-polyfills/semantic-embedder-api-polyfill.js
@@ -50,7 +50,18 @@ function applyPrefix(text, taskType) {
 async function isModelCached(modelId, dtype) {
   try {
     const { ModelRegistry } = await ensureTransformers();
-    return await ModelRegistry.is_cached(modelId, { dtype });
+    // include_processor: false avoids a network request for preprocessor_config.json,
+    // which this model doesn't have and would otherwise produce a 404.
+    const result = await ModelRegistry.is_cached_files(modelId, {
+      dtype,
+      include_processor: false,
+    });
+    // generation_config.json is an optional text-generation config that the
+    // transformers.js cache doesn't always persist; exclude it from the check.
+    const essential = result.files.filter(
+      (f) => f.file !== 'generation_config.json'
+    );
+    return essential.length > 0 && essential.every((f) => f.cached);
   } catch {
     return false;
   }

--- a/built-in-ai-task-apis-polyfills/semantic-embedder-api-polyfill.js
+++ b/built-in-ai-task-apis-polyfills/semantic-embedder-api-polyfill.js
@@ -1,0 +1,407 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * SemanticEmbedder API Polyfill
+ * Backed by EmbeddingGemma (onnx-community/embeddinggemma-300m-ONNX) via
+ * @huggingface/transformers, matching the model Chrome's built-in
+ * SemanticEmbedder API uses on-device.
+ *
+ * EmbeddingGemma is Google's 300M-parameter embedding model built on Gemma 3,
+ * producing 768-dimensional vectors. It requires task-specific prefixes on
+ * inputs so that query and document embeddings are optimized for retrieval.
+ */
+
+const DEFAULT_MODEL = 'onnx-community/embeddinggemma-300m-ONNX';
+// EmbeddingGemma activations do not support fp16. q8 gives a good balance of
+// model size and quality in the browser.
+const DEFAULT_DTYPE = 'q8';
+const MAX_INPUT_TOKENS = 2048;
+
+// EmbeddingGemma task-type prefixes (must match the model's training setup).
+const TASK_PREFIXES = {
+  query: 'task: search result | query: ',
+  document: 'title: none | text: ',
+  classification: 'task: classification | text: ',
+};
+
+// Tracks which model IDs are currently being downloaded.
+const downloadingModels = new Set();
+
+let transformersModule = null;
+
+async function ensureTransformers() {
+  if (!transformersModule) {
+    transformersModule = await import('@huggingface/transformers');
+    // Share cached model weights across different origins when the
+    // Cross-Origin Storage extension is present.
+    transformersModule.env.experimental_useCrossOriginStorage = true;
+  }
+  return transformersModule;
+}
+
+function applyPrefix(text, taskType) {
+  const prefix = TASK_PREFIXES[taskType] ?? TASK_PREFIXES.document;
+  return `${prefix}${text}`;
+}
+
+async function isModelCached(modelId, dtype) {
+  try {
+    const { ModelRegistry } = await ensureTransformers();
+    return await ModelRegistry.is_cached(modelId, { dtype });
+  } catch {
+    return false;
+  }
+}
+
+export class SemanticEmbedder {
+  #tokenizer = null;
+  #model = null;
+  #modelId = DEFAULT_MODEL;
+  #destroyed = false;
+  #destructionReason = null;
+
+  constructor(tokenizer, model, modelId) {
+    this.#tokenizer = tokenizer;
+    this.#model = model;
+    this.#modelId = modelId;
+  }
+
+  static _checkContext() {
+    const win =
+      this.__window || (typeof globalThis !== 'undefined' ? globalThis : null);
+    let isDestroyed = false;
+    try {
+      if (
+        !win ||
+        win.closed ||
+        (win.document && win.document.defaultView !== win)
+      ) {
+        isDestroyed = true;
+      }
+    } catch {
+      isDestroyed = true;
+    }
+    if (isDestroyed) {
+      let EX;
+      try {
+        EX = win?.DOMException || globalThis.DOMException || Error;
+      } catch {
+        EX = globalThis.DOMException || Error;
+      }
+      throw new EX('The execution context is not valid.', 'InvalidStateError');
+    }
+  }
+
+  _checkContext() {
+    this.constructor._checkContext();
+  }
+
+  static availability() {
+    const p = (async () => {
+      this._checkContext();
+      if (typeof WebAssembly === 'undefined') {
+        return 'unavailable';
+      }
+      const modelId = DEFAULT_MODEL;
+      if (downloadingModels.has(modelId)) {
+        return 'downloading';
+      }
+      if (await isModelCached(modelId, DEFAULT_DTYPE)) {
+        return 'available';
+      }
+      return 'downloadable';
+    })();
+    p.catch(() => {});
+    return p;
+  }
+
+  static create(options = {}) {
+    const p = this._createInternal(options);
+    p.catch(() => {});
+    return p;
+  }
+
+  static async _createInternal(options = {}) {
+    this._checkContext();
+
+    if (options.signal?.aborted) {
+      throw options.signal.reason || new DOMException('Aborted', 'AbortError');
+    }
+
+    const { AutoModel, AutoTokenizer } = await ensureTransformers();
+
+    const modelId = options.model || DEFAULT_MODEL;
+    const dtype = options.dtype || DEFAULT_DTYPE;
+
+    // Per spec §5.2 "create an AI model object": fireProgressEvent is an
+    // algorithm taking a single `loaded` argument (0–1 fraction); total is
+    // always 1 and lengthComputable is always true.
+    let fireProgressEvent = null;
+    let progressCallback = null;
+    if (options.monitor) {
+      const monitorTarget = new EventTarget();
+      options.monitor(monitorTarget);
+      fireProgressEvent = (loaded) => {
+        monitorTarget.dispatchEvent(
+          new ProgressEvent('downloadprogress', {
+            loaded,
+            total: 1,
+            lengthComputable: true,
+          })
+        );
+      };
+      // AutoModel.from_pretrained() automatically wraps the callback with
+      // DefaultProgressCallback, which aggregates per-file events into a
+      // single 'progress_total' event covering all model files. We listen
+      // only to that status so progress is monotonically 0→1 and not
+      // confused by per-file events from the tokenizer or individual ONNX
+      // shards, which each independently go 0→100%.
+      progressCallback = (progress) => {
+        if (progress.status === 'progress_total') {
+          fireProgressEvent(
+            progress.total > 0 ? progress.loaded / progress.total : 0
+          );
+        }
+      };
+    }
+
+    // Spec: fire loaded=0 before the download/initialization begins.
+    fireProgressEvent?.(0);
+
+    downloadingModels.add(modelId);
+    let tokenizer, model;
+    try {
+      [tokenizer, model] = await Promise.all([
+        AutoTokenizer.from_pretrained(modelId, {
+          progress_callback: progressCallback,
+        }),
+        AutoModel.from_pretrained(modelId, {
+          dtype,
+          progress_callback: progressCallback,
+        }),
+      ]);
+    } finally {
+      downloadingModels.delete(modelId);
+    }
+
+    if (options.signal?.aborted) {
+      model.dispose?.();
+      throw options.signal.reason || new DOMException('Aborted', 'AbortError');
+    }
+
+    // Spec: fire loaded=1 once the model is fully loaded and ready.
+    fireProgressEvent?.(1);
+
+    const embedder = new this(tokenizer, model, modelId);
+
+    if (options.signal) {
+      options.signal.addEventListener(
+        'abort',
+        () => {
+          embedder.destroy(options.signal.reason);
+        },
+        { once: true }
+      );
+    }
+
+    return embedder;
+  }
+
+  embed(input, options = {}) {
+    if (this.#destroyed) {
+      const p = Promise.reject(
+        this.#destructionReason ||
+          new DOMException('The embedder has been destroyed.', 'AbortError')
+      );
+      p.catch(() => {});
+      return p;
+    }
+    const p = this.#embedInternal(input, options);
+    p.catch(() => {});
+    return p;
+  }
+
+  async #embedInternal(input, options = {}) {
+    this._checkContext();
+
+    const signal = options.signal;
+    if (signal?.aborted) {
+      throw signal.reason || new DOMException('Aborted', 'AbortError');
+    }
+
+    const inputs = Array.isArray(input) ? input : [input];
+
+    if (inputs.length === 0) {
+      return {
+        embeddings: [],
+        metadata: {
+          embeddingSpace: this.#modelId,
+          maxInputTokens: MAX_INPUT_TOKENS,
+        },
+      };
+    }
+
+    // Apply EmbeddingGemma's task-specific prefixes before tokenization.
+    const taskType = options.taskType ?? 'document';
+    const prefixedInputs = inputs.map((text) => applyPrefix(text, taskType));
+
+    const tokenized = await this.#tokenizer(prefixedInputs, {
+      padding: true,
+      truncation: true,
+      max_length: MAX_INPUT_TOKENS,
+    });
+
+    if (signal?.aborted) {
+      throw signal.reason || new DOMException('Aborted', 'AbortError');
+    }
+
+    // EmbeddingGemma returns `sentence_embedding` directly — a [n, 768] tensor.
+    const { sentence_embedding } = await this.#model(tokenized);
+
+    if (signal?.aborted) {
+      throw signal.reason || new DOMException('Aborted', 'AbortError');
+    }
+
+    const dim = sentence_embedding.dims[1];
+    const data = sentence_embedding.data; // flat Float32Array of length n*768
+
+    const embeddings = inputs.map((_, i) => ({
+      values: data.slice(i * dim, (i + 1) * dim),
+    }));
+
+    return {
+      embeddings,
+      metadata: {
+        embeddingSpace: this.#modelId,
+        maxInputTokens: MAX_INPUT_TOKENS,
+      },
+    };
+  }
+
+  /**
+   * Computes cosine similarity between two embedding vectors.
+   * Useful for semantic search ranking.
+   */
+  static cosineSimilarity(a, b) {
+    if (a.length !== b.length) {
+      throw new RangeError('Embedding vectors must have the same dimension.');
+    }
+    let dot = 0;
+    let normA = 0;
+    let normB = 0;
+    for (let i = 0; i < a.length; i++) {
+      dot += a[i] * b[i];
+      normA += a[i] * a[i];
+      normB += b[i] * b[i];
+    }
+    if (normA === 0 || normB === 0) {
+      return 0;
+    }
+    return dot / (Math.sqrt(normA) * Math.sqrt(normB));
+  }
+
+  get inputQuota() {
+    return MAX_INPUT_TOKENS;
+  }
+
+  destroy(reason) {
+    if (this.#destroyed) {
+      return;
+    }
+    this.#destroyed = true;
+    this.#destructionReason =
+      reason ||
+      new DOMException('The embedder has been destroyed.', 'AbortError');
+    this.#model?.dispose?.();
+    this.#model = null;
+    this.#tokenizer = null;
+  }
+}
+
+// Global exposure if in browser
+if (typeof globalThis !== 'undefined' && globalThis.document) {
+  const apiName = 'SemanticEmbedder';
+  const forceFlag = '__FORCE_SEMANTIC_EMBEDDER_POLYFILL__';
+  const isForced = !!globalThis[forceFlag];
+
+  const inject = (win) => {
+    try {
+      if (!win || (win[apiName] && !win[apiName].__isPolyfill)) {
+        return;
+      }
+      if (!(apiName in win) || isForced) {
+        const LocalAPI = {
+          [apiName]: class extends SemanticEmbedder {},
+        }[apiName];
+        LocalAPI.prototype[Symbol.toStringTag] = apiName;
+        LocalAPI.__window = win;
+        LocalAPI.__isPolyfill = true;
+        LocalAPI.create = LocalAPI.create.bind(LocalAPI);
+        LocalAPI.availability = LocalAPI.availability.bind(LocalAPI);
+        win[apiName] = LocalAPI;
+      }
+    } catch {
+      // Ignore cross-origin errors
+    }
+  };
+
+  inject(globalThis);
+
+  if (typeof HTMLIFrameElement !== 'undefined') {
+    try {
+      const descriptor = Object.getOwnPropertyDescriptor(
+        HTMLIFrameElement.prototype,
+        'contentWindow'
+      );
+      if (descriptor?.get) {
+        Object.defineProperty(HTMLIFrameElement.prototype, 'contentWindow', {
+          get() {
+            const win = descriptor.get.call(this);
+            if (win) {
+              inject(win);
+            }
+            return win;
+          },
+          configurable: true,
+        });
+      }
+    } catch {
+      // Ignore
+    }
+  }
+
+  const observer = new MutationObserver((mutations) => {
+    for (const mutation of mutations) {
+      for (const node of mutation.addedNodes) {
+        if (node.tagName === 'IFRAME') {
+          inject(node.contentWindow);
+          node.addEventListener('load', () => inject(node.contentWindow), {
+            once: false,
+          });
+        }
+      }
+    }
+  });
+
+  if (globalThis.document?.documentElement) {
+    observer.observe(globalThis.document.documentElement, {
+      childList: true,
+      subtree: true,
+    });
+    globalThis.document.querySelectorAll('iframe').forEach((iframe) => {
+      inject(iframe.contentWindow);
+      iframe.addEventListener('load', () => inject(iframe.contentWindow), {
+        once: false,
+      });
+    });
+  }
+
+  if (globalThis[apiName]?.__isPolyfill) {
+    console.log(
+      `Polyfill: window.${apiName} is now backed by the ${apiName} API polyfill.`
+    );
+  }
+}

--- a/built-in-ai-task-apis-polyfills/vite.config.js
+++ b/built-in-ai-task-apis-polyfills/vite.config.js
@@ -29,12 +29,16 @@ export default defineConfig({
         ),
         translator: resolve(__dirname, 'translator-api-polyfill.js'),
         classifier: resolve(__dirname, 'classifier-api-polyfill.js'),
+        'semantic-embedder': resolve(
+          __dirname,
+          'semantic-embedder-api-polyfill.js'
+        ),
       },
       formats: ['es'],
       fileName: (format, entryName) => `${entryName}.js`,
     },
     rollupOptions: {
-      external: ['prompt-api-polyfill'],
+      external: ['prompt-api-polyfill', '@huggingface/transformers'],
     },
     target: 'esnext',
   },


### PR DESCRIPTION
Adds a polyfill for the proposed [SemanticEmbedder API](https://github.com/explainers-by-googlers/embedding-api), backed by [EmbeddingGemma 300M](https://huggingface.co/onnx-community/embeddinggemma-300m-ONNX) — the same model Chrome's built-in API uses on-device — running in-browser via `@huggingface/transformers`.

## What's included

- `semantic-embedder-api-polyfill.js` — implements `availability()`, `create()`, `embed()`, `destroy()`, `inputQuota`, and `cosineSimilarity()`, with correct 4-state availability, spec-compliant `downloadprogress` events (0→1 fractions, `total=1`), and cache detection via `ModelRegistry.is_cached()`
- `demo-semantic-embedder.html` — interactive demo with semantic search and single-text embedding
- `@huggingface/transformers` added as an optional peer dependency (`>=4.2.0`)
- README, `index.js`, `vite.config.js`, and `package.json` updated accordingly