### PR TITLE
refactor(cos-resource-fetcher): use singular requestFileHandle()

### DIFF
--- a/cos-resource-fetcher/package-lock.json
+++ b/cos-resource-fetcher/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cos-resource-fetcher",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cos-resource-fetcher",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "Apache-2.0"
     }
   }

--- a/cos-resource-fetcher/package.json
+++ b/cos-resource-fetcher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cos-resource-fetcher",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "Fetch resource blobs via Cross-Origin Storage (COS) with Cache API fallback. Defaults to Hugging Face SHA-256 resolution, but accepts any custom resolver.",
   "type": "module",
   "exports": {

--- a/cos-resource-fetcher/src/index.js
+++ b/cos-resource-fetcher/src/index.js
@@ -89,9 +89,7 @@ async function fetchViaCOS(url, { sha256, onProgress }) {
   const hash = { algorithm: 'SHA-256', value: sha256 };
 
   try {
-    const [handle] = await navigator.crossOriginStorage.requestFileHandles([
-      hash,
-    ]);
+    const handle = await navigator.crossOriginStorage.requestFileHandle(hash);
     const file = await handle.getFile();
     return new Blob([file], { type: file.type });
   } catch (err) {
@@ -100,8 +98,8 @@ async function fetchViaCOS(url, { sha256, onProgress }) {
     // Not yet in COS: download, then store for future use by any origin
     const blob = await fetchWithProgress(url, onProgress);
     try {
-      const [handle] = await navigator.crossOriginStorage.requestFileHandles(
-        [hash],
+      const handle = await navigator.crossOriginStorage.requestFileHandle(
+        hash,
         {
           create: true,
           origins: '*',


### PR DESCRIPTION
All call sites in `cos-resource-fetcher/src/index.js` pass a single hash and use a single handle. This switches to the new singular `requestFileHandle(hash, options)` API, which returns a `FileSystemFileHandle` directly rather than a single-element array.

This is consistent with how every known real-world COS implementation uses the API — no implementation ever passes more than one hash in a single call.

The rename is tracked in the COS spec repo: https://github.com/WICG/cross-origin-storage/issues/61