### PR TITLE
Update SemanticEmbedder polyfill to match latest Embedding API spec

### DIFF
--- a/built-in-ai-task-apis-polyfills/README.md
+++ b/built-in-ai-task-apis-polyfills/README.md
@@ -184,11 +184,14 @@ const embedder = await SemanticEmbedder.create({
 const { embeddings } = await embedder.embed('Hello world');
 console.log(embeddings[0].values); // Float32Array of 768 values
 
-// Semantic search: embed query and corpus with appropriate task prefixes
+// Semantic search: embed query and corpus with appropriate task prefixes.
+// Supported taskType values: 'semantic-similarity', 'retrieval-query',
+// 'retrieval-document', 'classification', 'clustering'. If omitted, the raw
+// string is embedded as-is with no prefix.
 const [queryResult, docsResult] = await Promise.all([
-  embedder.embed('What is machine learning?', { taskType: 'query' }),
+  embedder.embed('What is machine learning?', { taskType: 'retrieval-query' }),
   embedder.embed(['AI transforms software.', 'Paris is in France.'], {
-    taskType: 'document',
+    taskType: 'retrieval-document',
   }),
 ]);
 

--- a/built-in-ai-task-apis-polyfills/demo-semantic-embedder.html
+++ b/built-in-ai-task-apis-polyfills/demo-semantic-embedder.html
@@ -214,6 +214,15 @@ What is machine learning?</textarea
 The quick brown fox jumps over the lazy dog.</textarea
       >
       <div class="controls" style="margin-top: 0.5rem">
+        <label for="taskTypeSelect">taskType:</label>
+        <select id="taskTypeSelect">
+          <option value="">(none — raw input as-is)</option>
+          <option value="semantic-similarity">semantic-similarity</option>
+          <option value="retrieval-query">retrieval-query</option>
+          <option value="retrieval-document">retrieval-document</option>
+          <option value="classification">classification</option>
+          <option value="clustering">clustering</option>
+        </select>
         <button id="embedBtn">Embed</button>
       </div>
       <h3>Embedding Vector (first 16 values)</h3>
@@ -230,6 +239,7 @@ The quick brown fox jumps over the lazy dog.</textarea
       const addCorpusInput = document.getElementById('addCorpusInput');
       const queryInput = document.getElementById('queryInput');
       const singleInput = document.getElementById('singleInput');
+      const taskTypeSelect = document.getElementById('taskTypeSelect');
       const searchResults = document.getElementById('searchResults');
       const embedOutput = document.getElementById('embedOutput');
       const embedMeta = document.getElementById('embedMeta');
@@ -355,8 +365,8 @@ The quick brown fox jumps over the lazy dog.</textarea
           // EmbeddingGemma uses different task prefixes for queries vs documents,
           // so we embed them with the appropriate taskType in separate calls.
           const [queryResult, docsResult] = await Promise.all([
-            emb.embed(query, { taskType: 'query' }),
-            emb.embed(corpus, { taskType: 'document' }),
+            emb.embed(query, { taskType: 'retrieval-query' }),
+            emb.embed(corpus, { taskType: 'retrieval-document' }),
           ]);
 
           const queryVec = queryResult.embeddings[0].values;
@@ -418,14 +428,15 @@ The quick brown fox jumps over the lazy dog.</textarea
           const emb = await ensureEmbedder();
           statusEl.textContent = 'Embedding…';
 
-          const result = await emb.embed(text);
+          const taskType = taskTypeSelect.value || undefined;
+          const result = await emb.embed(text, { taskType });
           const values = result.embeddings[0].values;
 
           const preview = Array.from(values.slice(0, 16))
             .map((v) => v.toFixed(6))
             .join(', ');
           embedOutput.textContent = `[${preview}, … (${values.length} total)]`;
-          embedMeta.textContent = `Embedding space: ${result.metadata.embeddingSpace} | Max input tokens: ${result.metadata.maxInputTokens} | Dimensions: ${values.length}`;
+          embedMeta.textContent = `taskType: ${taskType ?? '(none)'} | Embedding space: ${result.metadata.embeddingSpace} | Max input tokens: ${result.metadata.maxInputTokens} | Dimensions: ${values.length}`;
           statusEl.textContent = 'Embedding complete.';
         } catch (err) {
           embedOutput.textContent = `Error: ${err.message}`;

--- a/built-in-ai-task-apis-polyfills/semantic-embedder-api-polyfill.js
+++ b/built-in-ai-task-apis-polyfills/semantic-embedder-api-polyfill.js
@@ -5,13 +5,15 @@
 
 /**
  * SemanticEmbedder API Polyfill
- * Backed by EmbeddingGemma (onnx-community/embeddinggemma-300m-ONNX) via
- * @huggingface/transformers, matching the model Chrome's built-in
- * SemanticEmbedder API uses on-device.
+ * Backed by EmbeddingGemma (https://huggingface.co/litert-community/embeddinggemma-300m),
+ * the same 300M-parameter model Chrome's built-in SemanticEmbedder API uses
+ * on-device. This polyfill runs the equivalent ONNX conversion
+ * (onnx-community/embeddinggemma-300m-ONNX) in-browser via
+ * @huggingface/transformers, producing 768-dimensional Float32Array vectors.
  *
- * EmbeddingGemma is Google's 300M-parameter embedding model built on Gemma 3,
- * producing 768-dimensional vectors. It requires task-specific prefixes on
- * inputs so that query and document embeddings are optimized for retrieval.
+ * The optional `taskType` passed to embed() selects a task-specific prefix
+ * so the embedding is optimized for that use case. When omitted, the raw
+ * string is embedded as-is with no prefix.
  */
 
 const DEFAULT_MODEL = 'onnx-community/embeddinggemma-300m-ONNX';
@@ -21,11 +23,17 @@ const DEFAULT_DTYPE = 'q8';
 const MAX_INPUT_TOKENS = 2048;
 
 // EmbeddingGemma task-type prefixes (must match the model's training setup).
+// See https://ai.google.dev/gemma/docs/embeddinggemma/model_card for the
+// full prompt table.
 const TASK_PREFIXES = {
-  query: 'task: search result | query: ',
-  document: 'title: none | text: ',
-  classification: 'task: classification | text: ',
+  'semantic-similarity': 'task: sentence similarity | query: ',
+  'retrieval-query': 'task: search result | query: ',
+  'retrieval-document': 'title: none | text: ',
+  classification: 'task: classification | query: ',
+  clustering: 'task: clustering | query: ',
 };
+
+const VALID_TASK_TYPES = new Set(Object.keys(TASK_PREFIXES));
 
 // Tracks which model IDs are currently being downloaded.
 const downloadingModels = new Set();
@@ -43,8 +51,9 @@ async function ensureTransformers() {
 }
 
 function applyPrefix(text, taskType) {
-  const prefix = TASK_PREFIXES[taskType] ?? TASK_PREFIXES.document;
-  return `${prefix}${text}`;
+  // No taskType means the raw input is embedded as-is, with no prefix.
+  const prefix = taskType ? TASK_PREFIXES[taskType] : undefined;
+  return prefix ? `${prefix}${text}` : text;
 }
 
 async function isModelCached(modelId, dtype) {
@@ -196,9 +205,8 @@ if (isWorker) {
           throw new Error('Model is not initialized in the worker.');
         }
 
-        const taskType = options.taskType ?? 'document';
         const prefixedInputs = inputs.map((text) =>
-          applyPrefix(text, taskType)
+          applyPrefix(text, options.taskType)
         );
 
         const tokenized = await workerTokenizer(prefixedInputs, {
@@ -518,6 +526,15 @@ export class SemanticEmbedder {
       throw signal.reason || new DOMException('Aborted', 'AbortError');
     }
 
+    if (
+      options.taskType !== undefined &&
+      !VALID_TASK_TYPES.has(options.taskType)
+    ) {
+      throw new TypeError(
+        `Failed to execute 'embed': The provided value '${options.taskType}' is not a valid enum value of type EmbedderTaskType.`
+      );
+    }
+
     const inputs = Array.isArray(input) ? input : [input];
 
     if (inputs.length === 0) {
@@ -564,7 +581,7 @@ export class SemanticEmbedder {
         requestId,
         inputs,
         options: {
-          taskType: options.taskType ?? 'document',
+          taskType: options.taskType,
         },
       });
     });


### PR DESCRIPTION
Replace the `taskType` enum (`query/document/classification`) with the spec's `semantic-similarity`, `retrieval-query`, `retrieval-document`, `classification`, and `clustering` values, each mapped to the correct `EmbeddingGemma` prefix. Embedding with no `taskType` now passes the raw string through as-is instead of defaulting to `document`, and an invalid `taskType` now throws a `TypeError`. Update the demo and README to match.