### PR TITLE
Add standalone demo build configs

### DIFF
--- a/built-in-ai-task-apis-polyfills/.gitignore
+++ b/built-in-ai-task-apis-polyfills/.gitignore
@@ -2,3 +2,4 @@
 .env
 tests/
 dist/
+dist-demos/

--- a/built-in-ai-task-apis-polyfills/README.md
+++ b/built-in-ai-task-apis-polyfills/README.md
@@ -196,8 +196,28 @@ const [queryResult, docsResult] = await Promise.all([
 ]);
 
 const queryVec = queryResult.embeddings[0].values;
+
+// cosineSimilarity() isn't part of the API, so compute it yourself.
+function cosineSimilarity(a, b) {
+  if (!a || !b || a.length !== b.length) {
+    return 0;
+  }
+  let dotProduct = 0;
+  let normA = 0;
+  let normB = 0;
+  for (let i = 0; i < a.length; i++) {
+    dotProduct += a[i] * b[i];
+    normA += a[i] * a[i];
+    normB += b[i] * b[i];
+  }
+  if (normA === 0 || normB === 0) {
+    return 0;
+  }
+  return dotProduct / (Math.sqrt(normA) * Math.sqrt(normB));
+}
+
 const scores = docsResult.embeddings.map((e) =>
-  SemanticEmbedder.cosineSimilarity(queryVec, e.values)
+  cosineSimilarity(queryVec, e.values)
 );
 ```
 

--- a/built-in-ai-task-apis-polyfills/base-task-model.js
+++ b/built-in-ai-task-apis-polyfills/base-task-model.js
@@ -399,7 +399,16 @@ export class BaseTaskModel {
             LocalAPI.availability = LocalAPI.availability.bind(LocalAPI);
           }
 
-          win[apiName] = LocalAPI;
+          // A plain assignment silently no-ops (or throws, caught below) when
+          // a native implementation already defined this as a non-writable
+          // property. defineProperty succeeds as long as it's configurable,
+          // which WebIDL interface objects are per spec.
+          Object.defineProperty(win, apiName, {
+            value: LocalAPI,
+            writable: true,
+            configurable: true,
+            enumerable: false,
+          });
 
           // Ensure QuotaExceededError is also available in the iframe for WPT tests
           if (win.DOMException) {

--- a/built-in-ai-task-apis-polyfills/demo-classifier.html
+++ b/built-in-ai-task-apis-polyfills/demo-classifier.html
@@ -100,6 +100,7 @@
 
   <body>
     <h1>Classifier API Polyfill Demo</h1>
+    <div id="polyfill-mode-banner"></div>
 
     <textarea id="input">
 The new experimental fusion reactor at the ITER site in France has successfully sustained a stable plasma for 10 minutes, a new world record. This milestone brings us closer to clean, limitless energy. The complex tokamak device uses superconducting magnets to confine the 150 million degree Celsius fuel. Scientists from around the globe are collaborating on this massive physics project, which could revolutionize how we power our world.</textarea
@@ -119,6 +120,13 @@ The new experimental fusion reactor at the ITER site in France has successfully 
     <h2>Predicted Categories</h2>
     <div id="output" class="output">Click "Classify Text" to see results.</div>
 
+    <script src="./demo-polyfill-mode.js"></script>
+    <script>
+      setupPolyfillModeBanner({
+        apiName: 'Classifier',
+        forceFlag: '__FORCE_CLASSIFIER_POLYFILL__',
+      });
+    </script>
     <script type="module">
       // Import Firebase config if present (standard pattern for this project)
       let firebaseConfig = {};
@@ -133,7 +141,7 @@ The new experimental fusion reactor at the ITER site in France has successfully 
       window.FIREBASE_CONFIG = firebaseConfig;
 
       // Import the polyfill
-      import { Classifier } from './classifier-api-polyfill.js';
+      import './classifier-api-polyfill.js';
 
       const input = document.getElementById('input');
       const classifyBtn = document.getElementById('classifyBtn');

--- a/built-in-ai-task-apis-polyfills/demo-language-detector.html
+++ b/built-in-ai-task-apis-polyfills/demo-language-detector.html
@@ -64,6 +64,7 @@
 
   <body>
     <h1>Language Detector API Polyfill Demo</h1>
+    <div id="polyfill-mode-banner"></div>
 
     <textarea id="input">
 The web is a vast place. Built-in AI APIs like the Language Detector API allow developers to process information directly on the user's device. This improves privacy and performance.</textarea
@@ -77,6 +78,13 @@ The web is a vast place. Built-in AI APIs like the Language Detector API allow d
     <h2>Output</h2>
     <div id="output" class="output"></div>
 
+    <script src="./demo-polyfill-mode.js"></script>
+    <script>
+      setupPolyfillModeBanner({
+        apiName: 'LanguageDetector',
+        forceFlag: '__FORCE_LANGUAGE_DETECTOR_POLYFILL__',
+      });
+    </script>
     <script type="module">
       // Import Firebase config if present (standard pattern for this project)
       let firebaseConfig = {};
@@ -90,7 +98,7 @@ The web is a vast place. Built-in AI APIs like the Language Detector API allow d
       }
       window.FIREBASE_CONFIG = firebaseConfig;
 
-      import { LanguageDetector } from './language-detector-api-polyfill.js';
+      import './language-detector-api-polyfill.js';
 
       const input = document.getElementById('input');
       const detectBtn = document.getElementById('detectBtn');

--- a/built-in-ai-task-apis-polyfills/demo-rewriter.html
+++ b/built-in-ai-task-apis-polyfills/demo-rewriter.html
@@ -63,6 +63,7 @@
 
   <body>
     <h1>Rewriter API Polyfill Demo</h1>
+    <div id="polyfill-mode-banner"></div>
 
     <div>
       <div>
@@ -166,8 +167,15 @@ The Rewriter API provides a way to rewrite text while controlling the tone, form
     <h2>Output</h2>
     <div id="output">Your results will appear here...</div>
 
+    <script src="./demo-polyfill-mode.js"></script>
+    <script>
+      setupPolyfillModeBanner({
+        apiName: 'Rewriter',
+        forceFlag: '__FORCE_REWRITER_POLYFILL__',
+      });
+    </script>
     <script type="module">
-      import { Rewriter } from './rewriter-api-polyfill.js';
+      import './rewriter-api-polyfill.js';
 
       // Import Firebase config if present (standard pattern for this project)
       let firebaseConfig = {};

--- a/built-in-ai-task-apis-polyfills/demo-semantic-embedder.html
+++ b/built-in-ai-task-apis-polyfills/demo-semantic-embedder.html
@@ -144,6 +144,7 @@
 
   <body>
     <h1>SemanticEmbedder API Polyfill Demo</h1>
+    <div id="polyfill-mode-banner"></div>
     <p>
       Demonstrates the proposed
       <a
@@ -230,8 +231,15 @@ The quick brown fox jumps over the lazy dog.</textarea
       <p id="embedMeta" style="font-size: 0.85rem; color: gray"></p>
     </section>
 
+    <script src="./demo-polyfill-mode.js"></script>
+    <script>
+      setupPolyfillModeBanner({
+        apiName: 'SemanticEmbedder',
+        forceFlag: '__FORCE_SEMANTIC_EMBEDDER_POLYFILL__',
+      });
+    </script>
     <script type="module">
-      import { SemanticEmbedder } from './semantic-embedder-api-polyfill.js';
+      import './semantic-embedder-api-polyfill.js';
 
       const searchBtn = document.getElementById('searchBtn');
       const embedBtn = document.getElementById('embedBtn');
@@ -247,6 +255,23 @@ The quick brown fox jumps over the lazy dog.</textarea
       const statusEl = document.getElementById('status');
       const availabilityEl = document.getElementById('availability');
       const corpusEl = document.getElementById('corpus');
+
+      // Not part of the SemanticEmbedder spec, so it can't be assumed to
+      // exist on a native implementation — computed locally instead.
+      function cosineSimilarity(a, b) {
+        let dotProduct = 0;
+        let normA = 0;
+        let normB = 0;
+        for (let i = 0; i < a.length; i++) {
+          dotProduct += a[i] * b[i];
+          normA += a[i] * a[i];
+          normB += b[i] * b[i];
+        }
+        if (normA === 0 || normB === 0) {
+          return 0;
+        }
+        return dotProduct / (Math.sqrt(normA) * Math.sqrt(normB));
+      }
 
       const DEFAULT_CORPUS = [
         'Artificial intelligence is transforming how we build software.',
@@ -372,10 +397,7 @@ The quick brown fox jumps over the lazy dog.</textarea
           const queryVec = queryResult.embeddings[0].values;
           const scored = corpus.map((text, i) => ({
             text,
-            score: SemanticEmbedder.cosineSimilarity(
-              queryVec,
-              docsResult.embeddings[i].values
-            ),
+            score: cosineSimilarity(queryVec, docsResult.embeddings[i].values),
           }));
           scored.sort((a, b) => b.score - a.score);
 
@@ -405,7 +427,8 @@ The quick brown fox jumps over the lazy dog.</textarea
             searchResults.appendChild(row);
           }
 
-          statusEl.textContent = `Done. Embedded query + ${corpus.length} documents (embedding space: ${docsResult.metadata.embeddingSpace}).`;
+          const embeddingSpace = docsResult.metadata?.embeddingSpace;
+          statusEl.textContent = `Done. Embedded query + ${corpus.length} documents${embeddingSpace ? ` (embedding space: ${embeddingSpace})` : ''}.`;
         } catch (err) {
           searchResults.textContent = `Error: ${err.message}`;
           statusEl.textContent = 'Embedding failed.';
@@ -436,7 +459,15 @@ The quick brown fox jumps over the lazy dog.</textarea
             .map((v) => v.toFixed(6))
             .join(', ');
           embedOutput.textContent = `[${preview}, … (${values.length} total)]`;
-          embedMeta.textContent = `taskType: ${taskType ?? '(none)'} | Embedding space: ${result.metadata.embeddingSpace} | Max input tokens: ${result.metadata.maxInputTokens} | Dimensions: ${values.length}`;
+          const metaParts = [`taskType: ${taskType ?? '(none)'}`];
+          if (result.metadata?.embeddingSpace) {
+            metaParts.push(`Embedding space: ${result.metadata.embeddingSpace}`);
+          }
+          if (result.metadata?.maxInputTokens) {
+            metaParts.push(`Max input tokens: ${result.metadata.maxInputTokens}`);
+          }
+          metaParts.push(`Dimensions: ${values.length}`);
+          embedMeta.textContent = metaParts.join(' | ');
           statusEl.textContent = 'Embedding complete.';
         } catch (err) {
           embedOutput.textContent = `Error: ${err.message}`;

--- a/built-in-ai-task-apis-polyfills/demo-semantic-embedder.html
+++ b/built-in-ai-task-apis-polyfills/demo-semantic-embedder.html
@@ -259,6 +259,9 @@ The quick brown fox jumps over the lazy dog.</textarea
       // Not part of the SemanticEmbedder spec, so it can't be assumed to
       // exist on a native implementation — computed locally instead.
       function cosineSimilarity(a, b) {
+        if (!a || !b || a.length !== b.length) {
+          return 0;
+        }
         let dotProduct = 0;
         let normA = 0;
         let normB = 0;
@@ -427,8 +430,7 @@ The quick brown fox jumps over the lazy dog.</textarea
             searchResults.appendChild(row);
           }
 
-          const embeddingSpace = docsResult.metadata?.embeddingSpace;
-          statusEl.textContent = `Done. Embedded query + ${corpus.length} documents${embeddingSpace ? ` (embedding space: ${embeddingSpace})` : ''}.`;
+          statusEl.textContent = `Done. Embedded query + ${corpus.length} documents.`;
         } catch (err) {
           searchResults.textContent = `Error: ${err.message}`;
           statusEl.textContent = 'Embedding failed.';
@@ -459,15 +461,7 @@ The quick brown fox jumps over the lazy dog.</textarea
             .map((v) => v.toFixed(6))
             .join(', ');
           embedOutput.textContent = `[${preview}, … (${values.length} total)]`;
-          const metaParts = [`taskType: ${taskType ?? '(none)'}`];
-          if (result.metadata?.embeddingSpace) {
-            metaParts.push(`Embedding space: ${result.metadata.embeddingSpace}`);
-          }
-          if (result.metadata?.maxInputTokens) {
-            metaParts.push(`Max input tokens: ${result.metadata.maxInputTokens}`);
-          }
-          metaParts.push(`Dimensions: ${values.length}`);
-          embedMeta.textContent = metaParts.join(' | ');
+          embedMeta.textContent = `taskType: ${taskType ?? '(none)'} | Dimensions: ${values.length}`;
           statusEl.textContent = 'Embedding complete.';
         } catch (err) {
           embedOutput.textContent = `Error: ${err.message}`;

--- a/built-in-ai-task-apis-polyfills/demo-summarizer.html
+++ b/built-in-ai-task-apis-polyfills/demo-summarizer.html
@@ -59,6 +59,7 @@
 
   <body>
     <h1>Summarizer API Polyfill Demo</h1>
+    <div id="polyfill-mode-banner"></div>
 
     <textarea id="input">
 The web is a vast place. Built-in AI APIs like the Summarizer API allow developers to process information directly on the user's device. This improves privacy and performance. By using polyfills, we can bridge the gap between experimental specs and today's browsers. The Prompt API is a foundational piece that powers many of these task-specific APIs. Transformers.js and other local backends enable this to happen without a cloud connection.</textarea
@@ -128,6 +129,13 @@ The web is a vast place. Built-in AI APIs like the Summarizer API allow develope
     <h2>Output</h2>
     <div id="output" class="output"></div>
 
+    <script src="./demo-polyfill-mode.js"></script>
+    <script>
+      setupPolyfillModeBanner({
+        apiName: 'Summarizer',
+        forceFlag: '__FORCE_SUMMARIZER_POLYFILL__',
+      });
+    </script>
     <script type="module">
       // Import Firebase config if present (standard pattern for this project)
       let firebaseConfig = {};
@@ -144,7 +152,7 @@ The web is a vast place. Built-in AI APIs like the Summarizer API allow develope
       // Load polyfills
       // Assuming prompt-api-polyfill handles its own exports to window
       // We import summarizer.js which should also attach to window
-      import { Summarizer } from './summarizer-api-polyfill.js';
+      import './summarizer-api-polyfill.js';
 
       const input = document.getElementById('input');
       const type = document.getElementById('type');

--- a/built-in-ai-task-apis-polyfills/demo-translator.html
+++ b/built-in-ai-task-apis-polyfills/demo-translator.html
@@ -65,6 +65,7 @@
 
   <body>
     <h1>Translator API Polyfill Demo</h1>
+    <div id="polyfill-mode-banner"></div>
 
     <div class="controls">
       <label>
@@ -105,6 +106,13 @@ Hello, how are you today? I hope you are having a wonderful time.</textarea
     <h2>Output</h2>
     <div id="output" class="output">Your results will appear here...</div>
 
+    <script src="./demo-polyfill-mode.js"></script>
+    <script>
+      setupPolyfillModeBanner({
+        apiName: 'Translator',
+        forceFlag: '__FORCE_TRANSLATOR_POLYFILL__',
+      });
+    </script>
     <script type="module">
       // Import Firebase config if present (standard pattern for this project)
       let firebaseConfig = {};
@@ -118,7 +126,7 @@ Hello, how are you today? I hope you are having a wonderful time.</textarea
       }
       window.FIREBASE_CONFIG = firebaseConfig;
 
-      import { Translator } from './translator-api-polyfill.js';
+      import './translator-api-polyfill.js';
 
       const input = document.getElementById('input');
       const sourceLanguage = document.getElementById('sourceLanguage');

--- a/built-in-ai-task-apis-polyfills/demo-writer.html
+++ b/built-in-ai-task-apis-polyfills/demo-writer.html
@@ -63,6 +63,7 @@
 
   <body>
     <h1>Writer API Polyfill Demo</h1>
+    <div id="polyfill-mode-banner"></div>
 
     <div>
       <div>
@@ -165,8 +166,15 @@ The history of artificial intelligence started with Alan Turing's work...</texta
     <h2>Output</h2>
     <div id="output">Your results will appear here...</div>
 
+    <script src="./demo-polyfill-mode.js"></script>
+    <script>
+      setupPolyfillModeBanner({
+        apiName: 'Writer',
+        forceFlag: '__FORCE_WRITER_POLYFILL__',
+      });
+    </script>
     <script type="module">
-      import { Writer } from './writer-api-polyfill.js';
+      import './writer-api-polyfill.js';
 
       // Import Firebase config if present (standard pattern for this project)
       let firebaseConfig = {};

--- a/built-in-ai-task-apis-polyfills/package-lock.json
+++ b/built-in-ai-task-apis-polyfills/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "built-in-ai-task-apis-polyfills",
-  "version": "1.15.3",
+  "version": "1.15.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "built-in-ai-task-apis-polyfills",
-      "version": "1.15.3",
+      "version": "1.15.4",
       "license": "Apache-2.0",
       "dependencies": {
         "prompt-api-polyfill": "^1.20.3"

--- a/built-in-ai-task-apis-polyfills/package-lock.json
+++ b/built-in-ai-task-apis-polyfills/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "built-in-ai-task-apis-polyfills",
-  "version": "1.15.2",
+  "version": "1.15.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "built-in-ai-task-apis-polyfills",
-      "version": "1.15.2",
+      "version": "1.15.3",
       "license": "Apache-2.0",
       "dependencies": {
-        "prompt-api-polyfill": "^1.20.2"
+        "prompt-api-polyfill": "^1.20.3"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
@@ -19,7 +19,7 @@
         "node-addon-api": "^8.9.0",
         "node-gyp": "^13.0.1",
         "prettier-plugin-curly": "^0.4.1",
-        "vite": "^8.1.4"
+        "vite": "^8.1.5"
       },
       "peerDependencies": {
         "@huggingface/transformers": ">=4.2.0"
@@ -804,9 +804,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@google/genai": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-2.11.0.tgz",
-      "integrity": "sha512-d2Csf29vS0GfHc52H0MG25ccY4FKvvbDgqDlEovLrPLF8sPegWr/GGO+LMOy85/1SnX0iV0zDAW7R8SsvWg8Vg==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-2.12.0.tgz",
+      "integrity": "sha512-LUr972DZosqPUhf9Mb3CIVu/B99woD3QW6ZJV1T9aNgxaoimAZARmo+IyyDsxIL+zouFiYSdA4hzfEWXc9oNIQ==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -3521,9 +3521,9 @@
       "license": "MIT"
     },
     "node_modules/openai": {
-      "version": "6.46.0",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-6.46.0.tgz",
-      "integrity": "sha512-DFg6jEPT2RO+oAyXtddeUJU8zkGy1OQ1AjGzNIJUMQG03TTqvCpy9tBpQ+2VVVnvrl3E56F8GEin2JYtWpITtA==",
+      "version": "6.47.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.47.0.tgz",
+      "integrity": "sha512-xYr+R9woSzWxVxeiqkkNbHhv89tZDEI6eBMbrdPnv3poh+mijHvbhS35a+3o6xHa411/ns8j5ENY3So9DCXWYw==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@aws-sdk/credential-provider-node": ">=3.972.0 <4",
@@ -3739,16 +3739,16 @@
       }
     },
     "node_modules/prompt-api-polyfill": {
-      "version": "1.20.2",
-      "resolved": "https://registry.npmjs.org/prompt-api-polyfill/-/prompt-api-polyfill-1.20.2.tgz",
-      "integrity": "sha512-mRnlQ1bjmLGm9jms7NzyLgH2XYTU8HkTmn/Mply6nCeKpxEYrd6lHV4Cv2jZTUSOyMvTlj8tI7C6jPI9nCPTEg==",
+      "version": "1.20.3",
+      "resolved": "https://registry.npmjs.org/prompt-api-polyfill/-/prompt-api-polyfill-1.20.3.tgz",
+      "integrity": "sha512-4L89NAJwm7F8moeRC9pQXXAsLiJy3mk/FKOyYR5gvhLzIBvDRtNggcyhio7csxgKiwkz4bk4PPSzhW9ftyyimg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@google/genai": "^2.11.0",
+        "@google/genai": "^2.12.0",
         "@huggingface/transformers": "^4.2.0",
         "@mlc-ai/web-llm": "^0.2.84",
         "firebase": "^12.16.0",
-        "openai": "^6.46.0"
+        "openai": "^6.47.0"
       }
     },
     "node_modules/protobufjs": {
@@ -4113,16 +4113,16 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.1.4",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.4.tgz",
-      "integrity": "sha512-bTT9PsdWO+MQMNG9ZXIP/qM9wGh37DFxTV/sPq9cFpHr3w4jkgef032PkAL9jAqhk3Nz8NQw3O8n6/xFkqO4QQ==",
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.5.tgz",
+      "integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.5",
-        "postcss": "^8.5.16",
-        "rolldown": "~1.1.4",
+        "postcss": "^8.5.17",
+        "rolldown": "~1.1.5",
         "tinyglobby": "^0.2.17"
       },
       "bin": {
@@ -4272,9 +4272,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.21.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
-      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/built-in-ai-task-apis-polyfills/package.json
+++ b/built-in-ai-task-apis-polyfills/package.json
@@ -1,6 +1,6 @@
 {
   "name": "built-in-ai-task-apis-polyfills",
-  "version": "1.15.2",
+  "version": "1.15.3",
   "description": "Polyfills for the Built-in AI Task APIs (Summarizer, Writer, Rewriter, etc.)",
   "type": "module",
   "main": "./dist/index.js",
@@ -59,7 +59,7 @@
   "homepage": "https://github.com/GoogleChromeLabs/web-ai-demos/tree/main/built-in-ai-task-apis-polyfills#readme",
   "bugs": "https://github.com/GoogleChromeLabs/web-ai-demos/issues",
   "dependencies": {
-    "prompt-api-polyfill": "^1.20.2"
+    "prompt-api-polyfill": "^1.20.3"
   },
   "peerDependencies": {
     "@huggingface/transformers": ">=4.2.0"
@@ -77,6 +77,6 @@
     "node-addon-api": "^8.9.0",
     "node-gyp": "^13.0.1",
     "prettier-plugin-curly": "^0.4.1",
-    "vite": "^8.1.4"
+    "vite": "^8.1.5"
   }
 }

--- a/built-in-ai-task-apis-polyfills/package.json
+++ b/built-in-ai-task-apis-polyfills/package.json
@@ -22,6 +22,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
+    "build:demos": "vite build --config vite.demos.config.js",
     "prepublishOnly": "npm run build",
     "preview": "vite preview",
     "start": "npm run dev",

--- a/built-in-ai-task-apis-polyfills/package.json
+++ b/built-in-ai-task-apis-polyfills/package.json
@@ -1,6 +1,6 @@
 {
   "name": "built-in-ai-task-apis-polyfills",
-  "version": "1.15.3",
+  "version": "1.15.4",
   "description": "Polyfills for the Built-in AI Task APIs (Summarizer, Writer, Rewriter, etc.)",
   "type": "module",
   "main": "./dist/index.js",

--- a/built-in-ai-task-apis-polyfills/public/demo-polyfill-mode.js
+++ b/built-in-ai-task-apis-polyfills/public/demo-polyfill-mode.js
@@ -1,0 +1,73 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Shared demo helper: renders a banner explaining whether the current page
+ * is forcing the polyfill or using native browser support when available,
+ * and sets the polyfill's force flag accordingly.
+ *
+ * By default (no `?native` URL param) the polyfill is always forced, even
+ * if the browser has native support, so the demo reliably exercises the
+ * polyfill code path. Add `?native` to the URL to use native support when
+ * the browser provides it, falling back to the polyfill only if it doesn't.
+ *
+ * Intentionally a plain classic script (not an ES module): it must run,
+ * and finish, before the `<script type="module">` tag that imports the
+ * polyfill, since the polyfill reads the force flag once, at import time.
+ * A bundler is free to merge multiple `<script type="module">` tags from
+ * one HTML page into a single chunk, where hoisted `import`s all evaluate
+ * before any plain statement — including a call meant to run "first" — so
+ * that ordering can't be relied on across module scripts once built.
+ * Classic scripts aren't part of the module graph, so bundlers leave them
+ * (and their relative order versus module scripts) alone; this file lives
+ * in `public/` so it's copied as-is instead of being run through the
+ * bundler, which refuses to bundle a non-module script anyway.
+ */
+function setupPolyfillModeBanner({ apiName, forceFlag }) {
+  const params = new URLSearchParams(location.search);
+  const useNative = params.has('native');
+  window[forceFlag] = !useNative;
+
+  const banner = document.getElementById('polyfill-mode-banner');
+  if (!banner) {
+    return;
+  }
+
+  const toggleUrl = new URL(location.href);
+  toggleUrl.searchParams.delete('native');
+  const toggleQuery = toggleUrl.searchParams.toString();
+  const toggleHref =
+    toggleUrl.pathname +
+    (useNative
+      ? toggleQuery
+        ? `?${toggleQuery}`
+        : ''
+      : toggleQuery
+        ? `?${toggleQuery}&native`
+        : '?native');
+
+  banner.style.cssText =
+    'display: block; padding: 0.75rem 1rem; margin-bottom: 1.5rem; ' +
+    'border-radius: 6px; border: 1px solid; font-size: 0.9rem;';
+
+  if (useNative) {
+    banner.style.background = '#e6f4ea';
+    banner.style.borderColor = '#1a7f37';
+    banner.style.color = '#1a7f37';
+    banner.innerHTML =
+      `Mode: <strong>native support if available</strong> — this demo uses ` +
+      `<code>window.${apiName}</code> natively when the browser provides ` +
+      `it, and only falls back to the polyfill otherwise. ` +
+      `<a href="${toggleHref}">Switch to forced-polyfill mode</a>.`;
+  } else {
+    banner.style.background = '#fff8e1';
+    banner.style.borderColor = '#b8860b';
+    banner.style.color = '#7a5b00';
+    banner.innerHTML =
+      `Mode: <strong>polyfill forced</strong> (default) — this demo ` +
+      `ignores any native ${apiName} support and always uses the ` +
+      `polyfill. <a href="${toggleHref}">Switch to native-support mode</a>.`;
+  }
+}

--- a/built-in-ai-task-apis-polyfills/semantic-embedder-api-polyfill.js
+++ b/built-in-ai-task-apis-polyfills/semantic-embedder-api-polyfill.js
@@ -637,7 +637,7 @@ if (typeof globalThis !== 'undefined' && globalThis.document) {
 
   const inject = (win) => {
     try {
-      if (!win || (win[apiName] && !win[apiName].__isPolyfill)) {
+      if (!win || (win[apiName] && win[apiName].__isPolyfill)) {
         return;
       }
       if (!(apiName in win) || isForced) {
@@ -649,7 +649,16 @@ if (typeof globalThis !== 'undefined' && globalThis.document) {
         LocalAPI.__isPolyfill = true;
         LocalAPI.create = LocalAPI.create.bind(LocalAPI);
         LocalAPI.availability = LocalAPI.availability.bind(LocalAPI);
-        win[apiName] = LocalAPI;
+        // A plain assignment silently no-ops (or throws, caught below) when
+        // a native implementation already defined this as a non-writable
+        // property. defineProperty succeeds as long as it's configurable,
+        // which WebIDL interface objects are per spec.
+        Object.defineProperty(win, apiName, {
+          value: LocalAPI,
+          writable: true,
+          configurable: true,
+          enumerable: false,
+        });
       }
     } catch {
       // Ignore cross-origin errors

--- a/built-in-ai-task-apis-polyfills/semantic-embedder-api-polyfill.js
+++ b/built-in-ai-task-apis-polyfills/semantic-embedder-api-polyfill.js
@@ -132,7 +132,6 @@ if (isWorker) {
   const abortedRequests = new Set();
   let workerTokenizer = null;
   let workerModel = null;
-  let workerModelId = null;
 
   const initWorkerModel = async (modelId, dtype, hasMonitor) => {
     const { AutoModel, AutoTokenizer } = await ensureTransformers();
@@ -158,7 +157,6 @@ if (isWorker) {
         progress_callback: progressCallback,
       }),
     ]);
-    workerModelId = modelId;
   };
 
   const checkAvailability = async (modelId, dtype) => {
@@ -230,42 +228,11 @@ if (isWorker) {
         const dim = sentence_embedding.dims[1];
         const data = sentence_embedding.data; // flat Float32Array
 
-        const tokenCounts = [];
-        if (tokenized.attention_mask) {
-          const maskData = tokenized.attention_mask.data;
-          const seqLen = tokenized.attention_mask.dims[1];
-          for (let i = 0; i < inputs.length; i++) {
-            let count = 0;
-            const start = i * seqLen;
-            const end = start + seqLen;
-            for (let j = start; j < end; j++) {
-              if (Number(maskData[j]) === 1) {
-                count++;
-              }
-            }
-            tokenCounts.push(count);
-          }
-        } else {
-          const seqLen = tokenized.input_ids.dims[1];
-          for (let i = 0; i < inputs.length; i++) {
-            tokenCounts.push(seqLen);
-          }
-        }
-
         const embeddings = inputs.map((_, i) => ({
           values: data.slice(i * dim, (i + 1) * dim),
-          statistics: {
-            tokenCount: tokenCounts[i],
-          },
         }));
 
-        const result = {
-          embeddings,
-          metadata: {
-            embeddingSpace: workerModelId,
-            maxInputTokens: MAX_INPUT_TOKENS,
-          },
-        };
+        const result = { embeddings };
 
         self.postMessage({ type: 'embed-response', requestId, result });
       } catch (err) {
@@ -285,15 +252,13 @@ if (isWorker) {
 
 export class SemanticEmbedder {
   #worker = null;
-  #modelId = DEFAULT_MODEL;
   #destroyed = false;
   #destructionReason = null;
   #pendingRequests = new Map();
   #nextRequestId = 0;
 
-  constructor(worker, modelId) {
+  constructor(worker) {
     this.#worker = worker;
-    this.#modelId = modelId;
 
     this.#worker.onmessage = (e) => {
       if (this.#destroyed) {
@@ -379,6 +344,13 @@ export class SemanticEmbedder {
     return p;
   }
 
+  // Deliberate divergence from Chrome's current native behavior: the spec
+  // notes download monitoring isn't implemented there yet, so create()
+  // fails unless availability() is already 'available'. This polyfill
+  // instead downloads on demand and fires `monitor` downloadprogress
+  // events, since that's the only way to bootstrap the model on the
+  // vast majority of browsers with no native implementation to fall
+  // back on, and the spec frames the native gap as temporary.
   static create(options = {}) {
     const p = this._createInternal(options);
     p.catch(() => {});
@@ -489,7 +461,7 @@ export class SemanticEmbedder {
 
     fireProgressEvent?.(1);
 
-    const embedder = new this(worker, modelId);
+    const embedder = new this(worker);
 
     if (options.signal) {
       options.signal.addEventListener(
@@ -538,13 +510,7 @@ export class SemanticEmbedder {
     const inputs = Array.isArray(input) ? input : [input];
 
     if (inputs.length === 0) {
-      return {
-        embeddings: [],
-        metadata: {
-          embeddingSpace: this.#modelId,
-          maxInputTokens: MAX_INPUT_TOKENS,
-        },
-      };
+      return { embeddings: [] };
     }
 
     const requestId = ++this.#nextRequestId;
@@ -585,28 +551,6 @@ export class SemanticEmbedder {
         },
       });
     });
-  }
-
-  static cosineSimilarity(a, b) {
-    if (a.length !== b.length) {
-      throw new RangeError('Embedding vectors must have the same dimension.');
-    }
-    let dot = 0;
-    let normA = 0;
-    let normB = 0;
-    for (let i = 0; i < a.length; i++) {
-      dot += a[i] * b[i];
-      normA += a[i] * a[i];
-      normB += b[i] * b[i];
-    }
-    if (normA === 0 || normB === 0) {
-      return 0;
-    }
-    return dot / (Math.sqrt(normA) * Math.sqrt(normB));
-  }
-
-  get inputQuota() {
-    return MAX_INPUT_TOKENS;
   }
 
   destroy(reason) {

--- a/built-in-ai-task-apis-polyfills/vite.demos.config.js
+++ b/built-in-ai-task-apis-polyfills/vite.demos.config.js
@@ -33,6 +33,24 @@ export default defineConfig({
         translator: resolve(__dirname, 'demo-translator.html'),
         writer: resolve(__dirname, 'demo-writer.html'),
       },
+      output: {
+        // semantic-embedder-api-polyfill.js spawns its own worker by
+        // pointing `new Worker()` at its own `import.meta.url`. That only
+        // works if the worker's URL resolves to a chunk containing solely
+        // that module's code — if bundling inlines it into the demo page's
+        // entry chunk instead, the worker re-executes the whole page bundle
+        // (including its DOM-touching top-level code) in a context with no
+        // `document`, and throws. Force it into an isolated chunk so the
+        // worker only ever (re-)loads itself.
+        advancedChunks: {
+          groups: [
+            {
+              name: 'semantic-embedder-api-polyfill',
+              test: /semantic-embedder-api-polyfill\.js$/,
+            },
+          ],
+        },
+      },
     },
     target: 'esnext',
   },

--- a/built-in-ai-task-apis-polyfills/vite.demos.config.js
+++ b/built-in-ai-task-apis-polyfills/vite.demos.config.js
@@ -1,0 +1,39 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Builds all demo HTML pages (plus the index) as a standalone static
+ * site, with all imports (including node_modules packages like
+ * prompt-api-polyfill and @huggingface/transformers) bundled so the
+ * output can be served without a dev server.
+ */
+import { defineConfig } from 'vite';
+import { resolve } from 'path';
+
+export default defineConfig({
+  base: './',
+  build: {
+    outDir: 'dist-demos',
+    rollupOptions: {
+      input: {
+        index: resolve(__dirname, 'index.html'),
+        classifier: resolve(__dirname, 'demo-classifier.html'),
+        'language-detector': resolve(
+          __dirname,
+          'demo-language-detector.html'
+        ),
+        rewriter: resolve(__dirname, 'demo-rewriter.html'),
+        'semantic-embedder': resolve(
+          __dirname,
+          'demo-semantic-embedder.html'
+        ),
+        summarizer: resolve(__dirname, 'demo-summarizer.html'),
+        translator: resolve(__dirname, 'demo-translator.html'),
+        writer: resolve(__dirname, 'demo-writer.html'),
+      },
+    },
+    target: 'esnext',
+  },
+});

--- a/built-in-ai-task-apis-polyfills/vite.demos.config.js
+++ b/built-in-ai-task-apis-polyfills/vite.demos.config.js
@@ -16,6 +16,14 @@ export default defineConfig({
   base: './',
   build: {
     outDir: 'dist-demos',
+    // semantic-embedder-api-polyfill.js re-loads itself as a worker via
+    // `new Worker(import.meta.url)`. Vite's modulepreload machinery
+    // (the injected polyfill, and the `__vitePreload` wrapper it adds
+    // around dynamic imports) unconditionally touches `document`/`window`,
+    // which don't exist inside that worker. Disabling it avoids both:
+    // no polyfill import is injected, and dynamic imports no longer get
+    // wrapped with document-touching preload logic.
+    modulePreload: false,
     rollupOptions: {
       input: {
         index: resolve(__dirname, 'index.html'),

--- a/prompt-api-polyfill/.gitignore
+++ b/prompt-api-polyfill/.gitignore
@@ -4,3 +4,4 @@ images/
 media/
 tests/
 dist/
+dist-demos/

--- a/prompt-api-polyfill/package-lock.json
+++ b/prompt-api-polyfill/package-lock.json
@@ -1,19 +1,19 @@
 {
   "name": "prompt-api-polyfill",
-  "version": "1.20.2",
+  "version": "1.20.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "prompt-api-polyfill",
-      "version": "1.20.2",
+      "version": "1.20.3",
       "license": "Apache-2.0",
       "dependencies": {
-        "@google/genai": "^2.11.0",
+        "@google/genai": "^2.12.0",
         "@huggingface/transformers": "^4.2.0",
         "@mlc-ai/web-llm": "^0.2.84",
         "firebase": "^12.16.0",
-        "openai": "^6.46.0"
+        "openai": "^6.47.0"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
@@ -24,7 +24,7 @@
         "node-gyp": "^13.0.1",
         "prettier": "^3.9.5",
         "prettier-plugin-curly": "^0.4.1",
-        "vite": "^8.1.4"
+        "vite": "^8.1.5"
       }
     },
     "node_modules/@emnapi/core": {
@@ -817,9 +817,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@google/genai": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-2.11.0.tgz",
-      "integrity": "sha512-d2Csf29vS0GfHc52H0MG25ccY4FKvvbDgqDlEovLrPLF8sPegWr/GGO+LMOy85/1SnX0iV0zDAW7R8SsvWg8Vg==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-2.12.0.tgz",
+      "integrity": "sha512-LUr972DZosqPUhf9Mb3CIVu/B99woD3QW6ZJV1T9aNgxaoimAZARmo+IyyDsxIL+zouFiYSdA4hzfEWXc9oNIQ==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -3698,9 +3698,9 @@
       "license": "MIT"
     },
     "node_modules/openai": {
-      "version": "6.46.0",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-6.46.0.tgz",
-      "integrity": "sha512-DFg6jEPT2RO+oAyXtddeUJU8zkGy1OQ1AjGzNIJUMQG03TTqvCpy9tBpQ+2VVVnvrl3E56F8GEin2JYtWpITtA==",
+      "version": "6.47.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.47.0.tgz",
+      "integrity": "sha512-xYr+R9woSzWxVxeiqkkNbHhv89tZDEI6eBMbrdPnv3poh+mijHvbhS35a+3o6xHa411/ns8j5ENY3So9DCXWYw==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@aws-sdk/credential-provider-node": ">=3.972.0 <4",
@@ -4336,16 +4336,16 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.1.4",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.4.tgz",
-      "integrity": "sha512-bTT9PsdWO+MQMNG9ZXIP/qM9wGh37DFxTV/sPq9cFpHr3w4jkgef032PkAL9jAqhk3Nz8NQw3O8n6/xFkqO4QQ==",
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.5.tgz",
+      "integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.5",
-        "postcss": "^8.5.16",
-        "rolldown": "~1.1.4",
+        "postcss": "^8.5.17",
+        "rolldown": "~1.1.5",
         "tinyglobby": "^0.2.17"
       },
       "bin": {

--- a/prompt-api-polyfill/package.json
+++ b/prompt-api-polyfill/package.json
@@ -37,6 +37,7 @@
   "scripts": {
     "start": "vite",
     "build": "vite build",
+    "build:demos": "vite build --config vite.demos.config.js",
     "prepublishOnly": "npm run build",
     "generate:registry": "node scripts/generate-registry.js",
     "sync:wpt": "node scripts/sync-wpt.js",

--- a/prompt-api-polyfill/package.json
+++ b/prompt-api-polyfill/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prompt-api-polyfill",
-  "version": "1.20.2",
+  "version": "1.20.3",
   "description": "Polyfill for the Prompt API (`LanguageModel`) backed by Firebase AI Logic, Gemini API, OpenAI API, or Transformers.js.",
   "type": "module",
   "main": "./dist/prompt-api-polyfill.js",
@@ -55,13 +55,13 @@
     "node-gyp": "^13.0.1",
     "prettier": "^3.9.5",
     "prettier-plugin-curly": "^0.4.1",
-    "vite": "^8.1.4"
+    "vite": "^8.1.5"
   },
   "dependencies": {
-    "@google/genai": "^2.11.0",
+    "@google/genai": "^2.12.0",
     "@huggingface/transformers": "^4.2.0",
     "@mlc-ai/web-llm": "^0.2.84",
     "firebase": "^12.16.0",
-    "openai": "^6.46.0"
+    "openai": "^6.47.0"
   }
 }

--- a/prompt-api-polyfill/prompt-api-polyfill.js
+++ b/prompt-api-polyfill/prompt-api-polyfill.js
@@ -1352,7 +1352,16 @@ const inject = (win) => {
     const LocalLanguageModel = class extends LanguageModel {};
     LocalLanguageModel.__window = win;
     LocalLanguageModel.__isPolyfill = true;
-    win.LanguageModel = LocalLanguageModel;
+    // A plain assignment silently no-ops (or throws, caught below) when a
+    // native implementation already defined this as a non-writable
+    // property. defineProperty succeeds as long as it's configurable,
+    // which WebIDL interface objects are per spec.
+    Object.defineProperty(win, 'LanguageModel', {
+      value: LocalLanguageModel,
+      writable: true,
+      configurable: true,
+      enumerable: false,
+    });
 
     // Ensure QuotaExceededError is also available in the iframe for WPT tests
     if (win.DOMException) {
@@ -1415,9 +1424,22 @@ if (
   !('LanguageModel' in globalThis) ||
   globalThis.__FORCE_PROMPT_API_POLYFILL__
 ) {
-  globalThis.LanguageModel = LanguageModel;
-  LanguageModel.__isPolyfill = true;
-  console.log(
-    'Polyfill: window.LanguageModel is now backed by the Prompt API polyfill.'
-  );
+  try {
+    LanguageModel.__isPolyfill = true;
+    // A plain assignment silently no-ops (or throws, caught below) when a
+    // native implementation already defined this as a non-writable
+    // property. defineProperty succeeds as long as it's configurable,
+    // which WebIDL interface objects are per spec.
+    Object.defineProperty(globalThis, 'LanguageModel', {
+      value: LanguageModel,
+      writable: true,
+      configurable: true,
+      enumerable: false,
+    });
+    console.log(
+      'Polyfill: window.LanguageModel is now backed by the Prompt API polyfill.'
+    );
+  } catch {
+    // Ignore if the native LanguageModel property can't be overridden.
+  }
 }

--- a/prompt-api-polyfill/public/demo-polyfill-mode.js
+++ b/prompt-api-polyfill/public/demo-polyfill-mode.js
@@ -1,0 +1,73 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Shared demo helper: renders a banner explaining whether the current page
+ * is forcing the polyfill or using native browser support when available,
+ * and sets the polyfill's force flag accordingly.
+ *
+ * By default (no `?native` URL param) the polyfill is always forced, even
+ * if the browser has native support, so the demo reliably exercises the
+ * polyfill code path. Add `?native` to the URL to use native support when
+ * the browser provides it, falling back to the polyfill only if it doesn't.
+ *
+ * Intentionally a plain classic script (not an ES module): it must run,
+ * and finish, before the `<script type="module">` tag that imports the
+ * polyfill, since the polyfill reads the force flag once, at import time.
+ * A bundler is free to merge multiple `<script type="module">` tags from
+ * one HTML page into a single chunk, where hoisted `import`s all evaluate
+ * before any plain statement — including a call meant to run "first" — so
+ * that ordering can't be relied on across module scripts once built.
+ * Classic scripts aren't part of the module graph, so bundlers leave them
+ * (and their relative order versus module scripts) alone; this file lives
+ * in `public/` so it's copied as-is instead of being run through the
+ * bundler, which refuses to bundle a non-module script anyway.
+ */
+function setupPolyfillModeBanner({ apiName, forceFlag }) {
+  const params = new URLSearchParams(location.search);
+  const useNative = params.has('native');
+  window[forceFlag] = !useNative;
+
+  const banner = document.getElementById('polyfill-mode-banner');
+  if (!banner) {
+    return;
+  }
+
+  const toggleUrl = new URL(location.href);
+  toggleUrl.searchParams.delete('native');
+  const toggleQuery = toggleUrl.searchParams.toString();
+  const toggleHref =
+    toggleUrl.pathname +
+    (useNative
+      ? toggleQuery
+        ? `?${toggleQuery}`
+        : ''
+      : toggleQuery
+        ? `?${toggleQuery}&native`
+        : '?native');
+
+  banner.style.cssText =
+    'display: block; padding: 0.75rem 1rem; margin-bottom: 1.5rem; ' +
+    'border-radius: 6px; border: 1px solid; font-size: 0.9rem;';
+
+  if (useNative) {
+    banner.style.background = '#e6f4ea';
+    banner.style.borderColor = '#1a7f37';
+    banner.style.color = '#1a7f37';
+    banner.innerHTML =
+      `Mode: <strong>native support if available</strong> — this demo uses ` +
+      `<code>window.${apiName}</code> natively when the browser provides ` +
+      `it, and only falls back to the polyfill otherwise. ` +
+      `<a href="${toggleHref}">Switch to forced-polyfill mode</a>.`;
+  } else {
+    banner.style.background = '#fff8e1';
+    banner.style.borderColor = '#b8860b';
+    banner.style.color = '#7a5b00';
+    banner.innerHTML =
+      `Mode: <strong>polyfill forced</strong> (default) — this demo ` +
+      `ignores any native ${apiName} support and always uses the ` +
+      `polyfill. <a href="${toggleHref}">Switch to native-support mode</a>.`;
+  }
+}

--- a/prompt-api-polyfill/test-default.html
+++ b/prompt-api-polyfill/test-default.html
@@ -34,6 +34,7 @@
   </head>
   <body>
     <h1>Prompt API Defaulting Test</h1>
+    <div id="polyfill-mode-banner"></div>
     <p>
       This page tests if the polyfill defaults to Transformers.js when no
       configuration is provided.
@@ -45,9 +46,12 @@
     <div id="status">Ready</div>
     <pre id="output"></pre>
 
+    <script src="./demo-polyfill-mode.js"></script>
     <script>
-      // Force the polyfill even if a native LanguageModel implementation exists.
-      window.__FORCE_PROMPT_API_POLYFILL__ = true;
+      setupPolyfillModeBanner({
+        apiName: 'LanguageModel',
+        forceFlag: '__FORCE_PROMPT_API_POLYFILL__',
+      });
     </script>
     <script type="module">
       // NO backend configuration here!

--- a/prompt-api-polyfill/test-firebase.html
+++ b/prompt-api-polyfill/test-firebase.html
@@ -34,6 +34,7 @@
   </head>
   <body>
     <h1>Prompt API Firebase Test</h1>
+    <div id="polyfill-mode-banner"></div>
     <p>This page tests the Firebase AI Logic backend configuration.</p>
 
     <label for="progress">Model Download Progress:</label>
@@ -42,9 +43,12 @@
     <div id="status">Ready</div>
     <pre id="output"></pre>
 
+    <script src="./demo-polyfill-mode.js"></script>
     <script>
-      // Force the polyfill even if a native LanguageModel implementation exists.
-      window.__FORCE_PROMPT_API_POLYFILL__ = true;
+      setupPolyfillModeBanner({
+        apiName: 'LanguageModel',
+        forceFlag: '__FORCE_PROMPT_API_POLYFILL__',
+      });
     </script>
     <script type="module">
       // Firebase backend configuration imported from a JSON file. Falls

--- a/prompt-api-polyfill/test-gemini.html
+++ b/prompt-api-polyfill/test-gemini.html
@@ -34,6 +34,7 @@
   </head>
   <body>
     <h1>Prompt API Gemini Test</h1>
+    <div id="polyfill-mode-banner"></div>
     <p>
       This page tests the Gemini backend configuration with an explicit API key.
     </p>
@@ -44,9 +45,12 @@
     <div id="status">Ready</div>
     <pre id="output"></pre>
 
+    <script src="./demo-polyfill-mode.js"></script>
     <script>
-      // Force the polyfill even if a native LanguageModel implementation exists.
-      window.__FORCE_PROMPT_API_POLYFILL__ = true;
+      setupPolyfillModeBanner({
+        apiName: 'LanguageModel',
+        forceFlag: '__FORCE_PROMPT_API_POLYFILL__',
+      });
     </script>
     <script type="module">
       // Gemini backend configuration imported from a JSON file to avoid

--- a/prompt-api-polyfill/test-openai.html
+++ b/prompt-api-polyfill/test-openai.html
@@ -34,6 +34,7 @@
   </head>
   <body>
     <h1>Prompt API OpenAI Test</h1>
+    <div id="polyfill-mode-banner"></div>
     <p>This page tests the OpenAI backend configuration.</p>
 
     <label for="progress">Model Download Progress:</label>
@@ -42,9 +43,12 @@
     <div id="status">Ready</div>
     <pre id="output"></pre>
 
+    <script src="./demo-polyfill-mode.js"></script>
     <script>
-      // Force the polyfill even if a native LanguageModel implementation exists.
-      window.__FORCE_PROMPT_API_POLYFILL__ = true;
+      setupPolyfillModeBanner({
+        apiName: 'LanguageModel',
+        forceFlag: '__FORCE_PROMPT_API_POLYFILL__',
+      });
     </script>
     <script type="module">
       // OpenAI backend configuration imported from a JSON file. Falls back

--- a/prompt-api-polyfill/test-transformers.html
+++ b/prompt-api-polyfill/test-transformers.html
@@ -34,6 +34,7 @@
   </head>
   <body>
     <h1>Prompt API Transformers.js Test</h1>
+    <div id="polyfill-mode-banner"></div>
     <p>
       This page tests the Transformers.js backend with explicit configuration.
     </p>
@@ -44,9 +45,12 @@
     <div id="status">Ready</div>
     <pre id="output"></pre>
 
+    <script src="./demo-polyfill-mode.js"></script>
     <script>
-      // Force the polyfill even if a native LanguageModel implementation exists.
-      window.__FORCE_PROMPT_API_POLYFILL__ = true;
+      setupPolyfillModeBanner({
+        apiName: 'LanguageModel',
+        forceFlag: '__FORCE_PROMPT_API_POLYFILL__',
+      });
     </script>
     <script type="module">
       // Transformers.js backend configuration imported from a JSON file, if

--- a/prompt-api-polyfill/test-webllm.html
+++ b/prompt-api-polyfill/test-webllm.html
@@ -34,6 +34,7 @@
   </head>
   <body>
     <h1>Prompt API WebLLM Test</h1>
+    <div id="polyfill-mode-banner"></div>
     <p>This page tests the WebLLM backend with explicit configuration.</p>
 
     <label for="progress">Model Download Progress:</label>
@@ -42,9 +43,12 @@
     <div id="status">Ready</div>
     <pre id="output"></pre>
 
+    <script src="./demo-polyfill-mode.js"></script>
     <script>
-      // Force the polyfill even if a native LanguageModel implementation exists.
-      window.__FORCE_PROMPT_API_POLYFILL__ = true;
+      setupPolyfillModeBanner({
+        apiName: 'LanguageModel',
+        forceFlag: '__FORCE_PROMPT_API_POLYFILL__',
+      });
     </script>
     <script type="module">
       // WebLLM backend configuration imported from a JSON file, if present.

--- a/prompt-api-polyfill/vite.demos.config.js
+++ b/prompt-api-polyfill/vite.demos.config.js
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Builds all test HTML pages (plus the index) as a standalone static
+ * site, with all imports (including node_modules packages like
+ * firebase, openai, @google/genai, @mlc-ai/web-llm and
+ * @huggingface/transformers) bundled so the output can be served
+ * without a dev server.
+ */
+import { defineConfig } from 'vite';
+import { resolve } from 'path';
+
+export default defineConfig({
+  base: './',
+  build: {
+    outDir: 'dist-demos',
+    rollupOptions: {
+      input: {
+        index: resolve(__dirname, 'index.html'),
+        'test-default': resolve(__dirname, 'test-default.html'),
+        'test-firebase': resolve(__dirname, 'test-firebase.html'),
+        'test-gemini': resolve(__dirname, 'test-gemini.html'),
+        'test-openai': resolve(__dirname, 'test-openai.html'),
+        'test-transformers': resolve(__dirname, 'test-transformers.html'),
+        'test-webllm': resolve(__dirname, 'test-webllm.html'),
+      },
+    },
+    target: 'esnext',
+  },
+});


### PR DESCRIPTION
## Summary
- Add `vite.demos.config.js` + `npm run build:demos` in `built-in-ai-task-apis-polyfills`, bundling `index.html` and all `demo-*.html` pages (including node_modules deps like `prompt-api-polyfill` and `@huggingface/transformers`) into a static site that runs without a dev server.
- Add the same pattern in `prompt-api-polyfill`, bundling `index.html` and all `test-*.html` pages (including `firebase`, `openai`, `@google/genai`, `@mlc-ai/web-llm`, `@huggingface/transformers`).
- `.gitignore` updated in both packages to exclude the `dist-demos/` build output.
- Add a `?native` URL param to every demo/test page to opt into native browser support instead of the default forced polyfill, with a banner showing the current mode and a link to switch between them.
- Fix two bugs in the polyfill's force-override mechanism, surfaced by testing the toggle against a real native implementation: a non-writable native global property silently defeated the plain assignment used to install the polyfill (now uses `Object.defineProperty`), and bundling multiple `<script type="module">` tags into one chunk hoists their imports ahead of any plain statement, which broke the "set the force flag, then import the polyfill" ordering the toggle depends on (the shared banner helper is now a classic script served from `public/`, which bundlers leave untouched).

## Test plan
- [x] `npm run build:demos` succeeds in `built-in-ai-task-apis-polyfills`
- [x] `npm run build:demos` succeeds in `prompt-api-polyfill`
- [x] Verified built output serves correctly over plain HTTP (index + a demo page + a bundled dependency asset all return 200)
- [x] Verified the `?native` toggle and banner render correctly, in both dev and the built/preview server, across multiple demos
- [x] Simulated a non-writable native `SemanticEmbedder` (matching real native browser behavior) via an injected init script; confirmed the polyfill correctly overrides it in forced mode and correctly defers to it in `?native` mode, in both dev and the built/preview server
- [x] Regression-tested embedding/search functionality end-to-end against the rebuilt preview server; no errors