### PR TITLE
Add prompt-api-telemetry: browser-side OpenInference tracing for the Prompt API

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Others showcase generic client-side AI using Transformers.js or Google's Gemma m
 
 - `weather-ai`: Uses Chrome's built-in Prompt API to generate a human-readable description of the weather from structured weather data provided by the OpenWeatherMap API.
 - `prompt-api-playground`: Showcases Chrome's built-in experimental Prompt API.
+- `prompt-api-telemetry`: PoC for exporting OpenInference traces from the Prompt API to Langfuse or LangSmith via OTLP/HTTP JSON.
 - `summarization-api-playground`: Showcases Chrome's built-in experimental Summarization API.
 - `speech-api-playground`: Showcases the Web Speech API for continuous speech recognition, interim results, and local on-device models.
 - `perf-client-side-gemma-worker`: Showcases web performance/UX tips for client-side Gen AI, based on a web worker. Uses an LLM (Google's Gemma 2) through MediaPipe.

--- a/prompt-api-telemetry/.gitignore
+++ b/prompt-api-telemetry/.gitignore
@@ -1,0 +1,2 @@
+config.js
+com.chrome.devtools.json

--- a/prompt-api-telemetry/README.md
+++ b/prompt-api-telemetry/README.md
@@ -1,0 +1,71 @@
+# Prompt API Telemetry
+
+Observability PoC for Chrome's Prompt API — a standalone demo based on [`prompt-api-playground`](../prompt-api-playground).
+
+## Motivation
+
+Teams shipping server-side GenAI products already rely on OpenTelemetry-based observability stacks to observe real behavior, evaluate, diagnose and implement an improvement loop.
+
+Built-in AI runs in the browser with no backend. The same observability stacks do not apply out of the box, which is a practical blocker for moving from demos to production. Without traces, teams cannot close the loop on prompt quality, latency, or failures for on-device inference.
+
+This PoC shows that **we can instrument Chrome's Prompt API in the client and export [OpenInference](https://arize-ai.github.io/openinference/spec/) traces to the same backends used for server-side GenAI services**. It is an early step toward observability parity between built-in AI and traditional GenAI — not a production-ready SDK.
+
+## What this is
+
+A copy of the Prompt API playground with OpenTelemetry instrumentation added. Export traces directly to an OpenTelemetry backend like Langfuse or LangSmith via OTLP/HTTP JSON.
+
+There is no app backend. Run it with `npm start`. The chat UI matches the playground — observability is layered on with minimal extra code.
+
+## Changes vs prompt-api-playground
+
+| File | Change |
+| ---- | ------ |
+| `script.js` | Imports `telemetry.js` + `config.js`; calls `initTelemetry()` on load; replaces `LanguageModel.create()` with `createInstrumentedSession()` |
+| `index.html` | Adds an OpenTelemetry import map in `<head>` (loads SDK from esm.sh) |
+| `telemetry.js` | **New.** OpenTelemetry setup, OTLP/console export, Prompt API span instrumentation |
+| `config.example.js` | **New.** Template for backend + credentials — copy to `config.js` |
+| `.gitignore` | **New.** Ignores `config.js` |
+
+Suggested review order: this README → `script.js` (diff vs playground) → `index.html` (import map only) → `config.example.js` → `telemetry.js` (core).
+
+## Setup
+
+```bash
+cd prompt-api-telemetry
+cp config.example.js config.js   # first time only — the app won't load without config.js
+npm start                        # or: npx http-server
+```
+
+Edit `config.js`:
+
+1. Set `backend` to `"langfuse"`, `"langsmith"`, or `"console"`
+2. Fill in the credentials for your chosen backend
+3. Reload the page
+
+Use `backend: "console"` to print spans to DevTools without exporting to an OpenTelemetry backend.
+
+`config.js` is gitignored — **never commit API keys**.
+
+## What gets traced
+
+| Span | Kind | When |
+| ---- | ---- | ---- |
+| `LanguageModel.create` | CHAIN | Session start — assigns a `session.id` |
+| `LanguageModel.promptStreaming` | LLM | Each prompt (streaming) |
+| `LanguageModel.destroy` | CHAIN | Session reset |
+
+Spans use [OpenInference](https://arize-ai.github.io/openinference/spec/) attributes: `llm.input_messages`, `llm.output_messages`, `llm.token_count.*`, `session.id` (groups turns into a thread), and `llm.time_to_first_token_ms`.
+
+## Future work
+
+### Client-safe credentials (prerequisite for next phase)
+
+This PoC puts full API keys in `config.js`. That is acceptable for a local developer setup, but **not** for shipping observability in a public client. Moving beyond PoC requires a credential that is safe to embed in frontend code — something like a scoped ingestion token with trace-export-only permissions, analogous to a Measurement ID in analytics stacks (public, narrow scope, no account access). Observability providers would need to offer this kind of client-safe credential, or document a supported proxy that holds the secret server-side.
+
+### Typed npm SDK
+
+Publish a typed npm package that bundles OpenTelemetry setup, backend config, and Prompt API instrumentation — so developers add a dependency instead of copying `telemetry.js` or wiring an esm.sh import map.
+
+### Other built-in AI APIs
+
+Extend instrumentation to the other [Chrome built-in AI APIs](https://developer.chrome.com/docs/ai/built-in-apis): Summarizer, Translator, Language Detector, Writer, Rewriter, and Proofreader.

--- a/prompt-api-telemetry/config.example.js
+++ b/prompt-api-telemetry/config.example.js
@@ -1,0 +1,73 @@
+/**
+ * Copyright 2026 Rakuten Group, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Telemetry export configuration. Copy this file to config.js and edit:
+ *
+ *   cp config.example.js config.js
+ *
+ * config.js is gitignored so API keys are not committed.
+ */
+
+/** @typedef {"console"|"langfuse"|"langsmith"} TelemetryBackend */
+
+export const telemetryConfig = {
+  /** @type {TelemetryBackend} */
+  backend: "console",
+
+  /** OpenTelemetry service.name and OpenInference project name. */
+  serviceName: "prompt-api-telemetry",
+
+  langfuse: {
+    baseUrl: "https://cloud.langfuse.com",
+    publicKey: "",
+    secretKey: "",
+  },
+
+  langsmith: {
+    baseUrl: "https://api.smith.langchain.com",
+    apiKey: "",
+    project: "prompt-api-telemetry",
+  },
+};
+
+/** @param {typeof telemetryConfig} config */
+export function toTelemetryOptions(config) {
+  const base = { serviceName: config.serviceName || "prompt-api-playground" };
+
+  if (config.backend === "console") {
+    return { ...base, mode: "console" };
+  }
+
+  switch (config.backend) {
+    case "langfuse": {
+      const { baseUrl, publicKey, secretKey } = config.langfuse;
+      const auth = btoa(`${publicKey}:${secretKey}`);
+      return {
+        ...base,
+        mode: "otlp",
+        otlpUrl: `${trimSlash(baseUrl)}/api/public/otel/v1/traces`,
+        otlpHeaders: {
+          Authorization: `Basic ${auth}`,
+          "x-langfuse-ingestion-version": "4",
+        },
+      };
+    }
+    case "langsmith": {
+      const { baseUrl, apiKey, project } = config.langsmith;
+      return {
+        ...base,
+        mode: "otlp",
+        otlpUrl: `${trimSlash(baseUrl)}/otel/v1/traces`,
+        otlpHeaders: { "x-api-key": apiKey, "Langsmith-Project": project },
+        resourceAttributes: { "langsmith.project": project },
+      };
+    }
+    default:
+      return { ...base, mode: "console" };
+  }
+}
+
+function trimSlash(url) {
+  return url.replace(/\/+$/, "");
+}

--- a/prompt-api-telemetry/index.html
+++ b/prompt-api-telemetry/index.html
@@ -1,0 +1,97 @@
+<!--
+  Copyright 2024 Google LLC
+  SPDX-License-Identifier: Apache-2.0
+ -->
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="color-scheme" content="dark light" />
+    <meta
+      http-equiv="origin-trial"
+      content="AoXwZGsUZlGEyuueX5nR6tujynrCfWhNWQnZcHTy3AZkXtCMULt/UJs6+/1Bp5jVw7Ue96Tcyf1IO8IRUMimAgcAAABeeyJvcmlnaW4iOiJodHRwczovL2Nocm9tZS5kZXY6NDQzIiwiZmVhdHVyZSI6IkFJUHJvbXB0QVBJTXVsdGltb2RhbElucHV0IiwiZXhwaXJ5IjoxNzc0MzEwNDAwfQ=="
+    />
+    <link
+      rel="icon"
+      href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>✨</text></svg>"
+    />
+    <link rel="stylesheet" href="style.css" />
+    <title>Prompt API Telemetry</title>
+    <script>
+      if (!isSecureContext) location.protocol = "https:";
+    </script>
+    <!-- Pin @opentelemetry/api via ?deps= so esm.sh loads a single shared copy -->
+    <script type="importmap">
+      {
+        "imports": {
+          "@opentelemetry/api": "https://esm.sh/@opentelemetry/api@1.9.0",
+          "@opentelemetry/resources": "https://esm.sh/@opentelemetry/resources@2.1.0?deps=@opentelemetry/api@1.9.0",
+          "@opentelemetry/sdk-trace-base": "https://esm.sh/@opentelemetry/sdk-trace-base@2.1.0?deps=@opentelemetry/api@1.9.0",
+          "@opentelemetry/sdk-trace-web": "https://esm.sh/@opentelemetry/sdk-trace-web@2.1.0?deps=@opentelemetry/api@1.9.0",
+          "@opentelemetry/exporter-trace-otlp-http": "https://esm.sh/@opentelemetry/exporter-trace-otlp-http@0.205.0?deps=@opentelemetry/api@1.9.0"
+        }
+      }
+    </script>
+    <script src="script.js" type="module"></script>
+  </head>
+  <body>
+    <h1>✨ Prompt API Playground</h1>
+    <p>
+      This is a demo of Chrome's
+      <a href="https://developer.chrome.com/docs/ai/built-in"
+        >built-in Prompt API</a
+      >
+      powered by Gemini Nano.
+    </p>
+    <div id="error-message"></div>
+    <div id="prompt-area">
+      <form>
+        <label>
+          Prompt
+          <textarea id="prompt-input"></textarea>
+        </label>
+        <button type="submit" id="submit-button">Submit prompt</button>
+        <button type="button" id="reset-button">Reset session</button>
+        <span id="cost"></span>
+      </form>
+      <h2>Session stats</h2>
+      <table>
+        <thead>
+          <tr>
+            <th>Tokens so far</th>
+            <th>Tokens left</th>
+            <th>Total tokens</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td id="tokens-so-far">&nbsp;</td>
+            <td id="tokens-left">&nbsp;</td>
+            <td id="max-tokens">&nbsp;</td>
+          </tr>
+        </tbody>
+      </table>
+      <h2>Conversation</h2>
+      <div id="response-area"></div>
+      <details>
+        <summary>Raw response</summary>
+        <div></div>
+      </details>
+      <button id="copy-link-button">Copy link</button>
+      <small
+        >💡 If there's a problem with the response, select the problematic text
+        with your mouse before clicking the button.</small
+      >
+      <div id="problematic-area">
+        <h2>Problematic:</h2>
+        <pre id="problem"></pre>
+      </div>
+    </div>
+    <footer>
+      Made by
+      <a href="https://github.com/tomayac/">@tomayac</a>. Source code on
+      <a href="https://github.com/GoogleChromeLabs/web-ai-demos">GitHub</a>.
+    </footer>
+  </body>
+</html>

--- a/prompt-api-telemetry/package-lock.json
+++ b/prompt-api-telemetry/package-lock.json
@@ -1,0 +1,616 @@
+{
+  "name": "prompt-api-playground",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "prompt-api-playground",
+      "version": "1.0.0",
+      "license": "Apache-2.0",
+      "devDependencies": {
+        "http-server": "^14.1.1",
+        "prettier": "^3.3.3"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/async": {
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.14"
+      }
+    },
+    "node_modules/basic-auth": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
+      "integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
+      "integrity": "sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "set-function-length": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/corser": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/corser/-/corser-2.0.1.tgz",
+      "integrity": "sha512-utCYNzRSQIZNPIcGZdQc92UVJYAhtGAteCFg0yRaFm8f0P+CPtyGyHXJcGXnffjCybUCEx3FQ2G7U3/o9eIkVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
+      "integrity": "sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-intrinsic": "^1.2.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
+      "integrity": "sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "has-proto": "^1.0.1",
+        "has-symbols": "^1.0.3",
+        "hasown": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
+      "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-intrinsic": "^1.1.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-proto": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.3.tgz",
+      "integrity": "sha512-SJ1amZAJUiZS+PhsVLf5tGydlaVB8EdFpaSO4gmiUKUOxk8qzn5AIy4ZeJUmh22znIdk/uMAUT2pl3FxzVUH+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "he": "bin/he"
+      }
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz",
+      "integrity": "sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/http-proxy": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.1.tgz",
+      "integrity": "sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eventemitter3": "^4.0.0",
+        "follow-redirects": "^1.0.0",
+        "requires-port": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/http-server": {
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/http-server/-/http-server-14.1.1.tgz",
+      "integrity": "sha512-+cbxadF40UXd9T01zUHgA+rlo2Bg1Srer4+B4NwIHdaGxAGGv59nYRnGGDJ9LBk7alpS0US+J+bLLdQOOkJq4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "basic-auth": "^2.0.1",
+        "chalk": "^4.1.2",
+        "corser": "^2.0.1",
+        "he": "^1.2.0",
+        "html-encoding-sniffer": "^3.0.0",
+        "http-proxy": "^1.18.1",
+        "mime": "^1.6.0",
+        "minimist": "^1.2.6",
+        "opener": "^1.5.1",
+        "portfinder": "^1.0.28",
+        "secure-compare": "3.0.1",
+        "union": "~0.5.0",
+        "url-join": "^4.0.1"
+      },
+      "bin": {
+        "http-server": "bin/http-server"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.2.tgz",
+      "integrity": "sha512-IRZSRuzJiynemAXPYtPe5BoI/RESNYR7TYm50MC5Mqbd3Jmw5y790sErYw3V6SryFJD64b74qQQs9wn5Bg/k3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/opener": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
+      "integrity": "sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==",
+      "dev": true,
+      "license": "(WTFPL OR MIT)",
+      "bin": {
+        "opener": "bin/opener-bin.js"
+      }
+    },
+    "node_modules/portfinder": {
+      "version": "1.0.32",
+      "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.32.tgz",
+      "integrity": "sha512-on2ZJVVDXRADWE6jnQaX0ioEylzgBpQk8r55NE4wjXW1ZxO+BgDlY6DXwj20i0V8eB4SenDQ00WEaxfiIQPcxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "async": "^2.6.4",
+        "debug": "^3.2.7",
+        "mkdirp": "^0.5.6"
+      },
+      "engines": {
+        "node": ">= 0.12.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.3.tgz",
+      "integrity": "sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
+      "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.0.6"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/secure-compare": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/secure-compare/-/secure-compare-3.0.1.tgz",
+      "integrity": "sha512-AckIIV90rPDcBcglUwXPF3kg0P0qmPsPXAj6BBEENQE1p5yA1xfmDJzfi1Tappj37Pv2mVbKpL3Z1T+Nn7k1Qw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.6.tgz",
+      "integrity": "sha512-fDW/EZ6Q9RiO8eFG8Hj+7u/oW+XrPTIChwCOM2+th2A6OblDtYYIpve9m+KvI9Z4C9qSEXlaGR6bTEYHReuglA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.4",
+        "object-inspect": "^1.13.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/union": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/union/-/union-0.5.0.tgz",
+      "integrity": "sha512-N6uOhuW6zO95P3Mel2I2zMsbsanvvtgn6jVqJv4vbVcz/JN0OkL9suomjQGmWtxJQXOCqUJvquc1sMeNz/IwlA==",
+      "dev": true,
+      "dependencies": {
+        "qs": "^6.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/url-join": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
+      "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-2.0.0.tgz",
+      "integrity": "sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    }
+  }
+}

--- a/prompt-api-telemetry/package.json
+++ b/prompt-api-telemetry/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "prompt-api-playground",
+  "version": "1.0.0",
+  "description": "This is a demo of Chrome's experimental Prompt API.",
+  "scripts": {
+    "start": "npx http-server",
+    "fix": "prettier --write ."
+  },
+  "author": "Thomas Steiner (tomac@google.com)",
+  "license": "Apache-2.0",
+  "devDependencies": {
+    "http-server": "^14.1.1",
+    "prettier": "^3.3.3"
+  }
+}

--- a/prompt-api-telemetry/script.js
+++ b/prompt-api-telemetry/script.js
@@ -1,0 +1,239 @@
+/**
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { marked } from "https://cdn.jsdelivr.net/npm/marked@13.0.3/lib/marked.esm.js";
+import DOMPurify from "https://cdn.jsdelivr.net/npm/dompurify@3.1.6/dist/purify.es.mjs";
+
+import { initTelemetry, createInstrumentedSession } from "./telemetry.js";
+import { telemetryConfig, toTelemetryOptions } from "./config.js";
+
+const NUMBER_FORMAT_LANGUAGE = "en-US";
+const SYSTEM_PROMPT = "You are a helpful and friendly assistant.";
+
+(async () => {
+  const errorMessage = document.getElementById("error-message");
+  const costSpan = document.getElementById("cost");
+  const promptArea = document.getElementById("prompt-area");
+  const problematicArea = document.getElementById("problematic-area");
+  const promptInput = document.getElementById("prompt-input");
+  const responseArea = document.getElementById("response-area");
+  const copyLinkButton = document.getElementById("copy-link-button");
+  const resetButton = document.getElementById("reset-button");
+  const copyHelper = document.querySelector("small");
+  const rawResponse = document.querySelector("details div");
+  const form = document.querySelector("form");
+  const maxTokensInfo = document.getElementById("max-tokens");
+  const tokensLeftInfo = document.getElementById("tokens-left");
+  const tokensSoFarInfo = document.getElementById("tokens-so-far");
+
+  await initTelemetry(toTelemetryOptions(telemetryConfig));
+
+  responseArea.style.display = "none";
+
+  let session = null;
+
+  if (!("LanguageModel" in self)) {
+    errorMessage.style.display = "block";
+    errorMessage.innerHTML = `Your browser doesn't support the Prompt API. If you're on Chrome, join the <a href="https://goo.gle/chrome-ai-dev-preview-join">Early Preview Program</a> to enable it.`;
+    return;
+  }
+
+  promptArea.style.display = "block";
+  copyLinkButton.style.display = "none";
+  copyHelper.style.display = "none";
+
+  const promptModel = async (highlight = false) => {
+    copyLinkButton.style.display = "none";
+    copyHelper.style.display = "none";
+    problematicArea.style.display = "none";
+    const prompt = promptInput.value.trim();
+    if (!prompt) return;
+    responseArea.style.display = "block";
+    const heading = document.createElement("h3");
+    heading.classList.add("prompt", "speech-bubble");
+    heading.textContent = prompt;
+    responseArea.append(heading);
+    const p = document.createElement("p");
+    p.classList.add("response", "speech-bubble");
+    p.textContent = "Generating response...";
+    responseArea.append(p);
+
+    try {
+      if (!session) {
+        await updateSession();
+        updateStats();
+      }
+      const stream = await session.promptStreaming(prompt);
+
+      let result = "";
+      let previousChunk = "";
+      for await (const chunk of stream) {
+        const newChunk = chunk.startsWith(previousChunk)
+          ? chunk.slice(previousChunk.length)
+          : chunk;
+        result += newChunk;
+        p.innerHTML = DOMPurify.sanitize(marked.parse(result));
+        rawResponse.innerText = result;
+        previousChunk = chunk;
+      }
+    } catch (error) {
+      p.textContent = `Error: ${error.message}`;
+    } finally {
+      if (highlight) {
+        problematicArea.style.display = "block";
+        problematicArea.querySelector("#problem").innerText =
+          decodeURIComponent(highlight).trim();
+      }
+      copyLinkButton.style.display = "inline-block";
+      copyHelper.style.display = "inline";
+      updateStats();
+    }
+  };
+
+  const updateStats = () => {
+    if (!session) {
+      return;
+    }
+
+    const numberFormat = new Intl.NumberFormat(NUMBER_FORMAT_LANGUAGE);
+    const decimalNumberFormat = new Intl.NumberFormat(NUMBER_FORMAT_LANGUAGE, {
+      minimumFractionDigits: 1,
+      maximumFractionDigits: 1,
+    });
+
+    // In the latest API shape, currently in Chrome Canary, `session.inputQuota` was
+    // renamed to `session.contextWindow` and `session.inputUsage` was renamed to
+    // `session.contextUsage`. Previously `session.maxTokens` was renamed to
+    // `session.inputQuota` and `session.tokensSoFar` was renamed to `session.inputUsage`.
+    // `session.tokensSoFar` was removed, but the value can be calculated by subtracting
+    // `inputUsage` from `inputQuota`. All APIs shapes are checked in the code below.
+    maxTokensInfo.textContent = numberFormat.format(
+      session.contextWindow ?? session.inputQuota ?? session.maxTokens,
+    );
+    tokensLeftInfo.textContent = numberFormat.format(
+      session.tokensSoFar ??
+        session.contextWindow - session.contextUsage ??
+        session.inputQuota - session.inputUsage,
+    );
+    tokensSoFarInfo.textContent = numberFormat.format(
+      session.contextUsage ?? session.inputUsage ?? session.tokensSoFar,
+    );
+  };
+
+  const params = new URLSearchParams(location.search);
+  const urlPrompt = params.get("prompt");
+  const highlight = params.get("highlight");
+  if (urlPrompt) {
+    promptInput.value = decodeURIComponent(urlPrompt).trim();
+    await promptModel(highlight);
+  }
+
+  form.addEventListener("submit", async (e) => {
+    e.preventDefault();
+    await promptModel();
+  });
+
+  promptInput.addEventListener("keydown", (e) => {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      form.dispatchEvent(new Event("submit"));
+    }
+  });
+
+  promptInput.addEventListener("focus", () => {
+    promptInput.select();
+  });
+
+  promptInput.addEventListener("input", async () => {
+    if (!session) {
+      return;
+    }
+
+    const value = promptInput.value.trim();
+    if (!value) {
+      return;
+    }
+
+    let cost;
+
+    // The API that returns the token count for a prompt has been renamed
+    // from `countPromptTokens(input)` to `measureInputUsage(input)` to
+    // `measureContextUsage(input)`.
+    // The code below ensures all cases are handled.
+    if (session.countPromptTokens) {
+      cost = await session.countPromptTokens(value);
+    } else if (session.measureContextUsage) {
+      cost = await session.measureContextUsage(value);
+    } else if (session.measureInputUsage) {
+      cost = await session.measureInputUsage(value);
+    }
+
+    if (!cost) {
+      return;
+    }
+    costSpan.textContent = `${cost} token${cost === 1 ? "" : "s"}`;
+  });
+
+  const resetUI = () => {
+    responseArea.style.display = "none";
+    responseArea.innerHTML = "";
+    rawResponse.innerHTML = "";
+    problematicArea.style.display = "none";
+    copyLinkButton.style.display = "none";
+    copyHelper.style.display = "none";
+    maxTokensInfo.textContent = "";
+    tokensLeftInfo.textContent = "";
+    tokensSoFarInfo.textContent = "";
+    promptInput.focus();
+  };
+
+  resetButton.addEventListener("click", () => {
+    promptInput.value = "";
+    resetUI();
+    session.destroy();
+    session = null;
+    updateSession();
+  });
+
+  copyLinkButton.addEventListener("click", () => {
+    const prompt = promptInput.value.trim();
+    if (!prompt) return;
+    const url = new URL(self.location.href);
+    url.searchParams.set("prompt", encodeURIComponent(prompt));
+    const selection = getSelection().toString() || "";
+    if (selection) {
+      url.searchParams.set("highlight", encodeURIComponent(selection));
+    } else {
+      url.searchParams.delete("highlight");
+    }
+    navigator.clipboard.writeText(url.toString()).catch((err) => {
+      alert("Failed to copy link: ", err);
+    });
+    const text = copyLinkButton.textContent;
+    copyLinkButton.textContent = "Copied";
+    setTimeout(() => {
+      copyLinkButton.textContent = text;
+    }, 3000);
+  });
+
+  const updateSession = async () => {
+    if (self.LanguageModel) {
+      session = await createInstrumentedSession({
+        initialPrompts: [
+          {
+            role: "system",
+            content: SYSTEM_PROMPT,
+          },
+        ],
+      });
+    }
+    resetUI();
+    updateStats();
+  };
+
+  if (!session) {
+    await updateSession();
+  }
+})();

--- a/prompt-api-telemetry/style.css
+++ b/prompt-api-telemetry/style.css
@@ -1,0 +1,168 @@
+/**
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+:root {
+  color-scheme: dark light;
+}
+
+html {
+  box-sizing: border-box;
+}
+
+*,
+*:before,
+*:after {
+  box-sizing: inherit;
+}
+
+body {
+  font-family: system-ui, sans-serif;
+  max-width: clamp(320px, 90%, 1000px);
+  margin: auto;
+}
+
+h2,
+h3 {
+  margin-block-end: 0;
+}
+
+#error-message,
+#problem {
+  border: red solid 2px;
+  padding: 0.25rem;
+}
+
+#prompt-area {
+  margin-block-end: 1rem;
+}
+
+#prompt-area,
+#error-message,
+#problematic-area {
+  display: none;
+}
+
+.prompt,
+.response {
+  font-size: 1rem;
+  font-weight: normal;
+  padding: 1.5rem;
+}
+
+.response {
+  background: #f4b400;
+  color: black;
+}
+
+.prompt {
+  background: #4285f4;
+}
+
+.speech-bubble {
+  position: relative;
+  border-radius: 0.4em;
+}
+
+.speech-bubble:after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  width: 0;
+  height: 0;
+  border: 24px solid transparent;
+  margin-top: -24px;
+}
+
+.response.speech-bubble:after {
+  right: 0;
+  border-left-color: #f4b400;
+  border-right: 0;
+  margin-right: -24px;
+}
+
+.prompt.speech-bubble:after {
+  left: 0;
+  border-right-color: #4285f4;
+  border-left: 0;
+  margin-left: -24px;
+}
+
+textarea {
+  width: 100%;
+  height: 6rem;
+}
+
+#response-area {
+  white-space: pre-wrap;
+  padding: 1rem;
+  margin-top: 1rem;
+}
+
+details {
+  padding-block: 1rem;
+}
+
+details div {
+  padding: 1rem;
+}
+
+.settings {
+  width: min-content;
+  gap: 1rem;
+  margin: 1rem;
+  display: grid;
+  grid-template-columns: 2fr 1fr;
+}
+
+label {
+  margin-bottom: 0.3em;
+  font-weight: bold;
+}
+
+summary {
+  cursor: pointer;
+  padding: 5px 10px;
+  background-color: gray;
+  color: white;
+  border: none;
+  border-radius: 5px;
+  min-width: 130px;
+  width: min-content;
+}
+
+th,
+td {
+  padding: 0.5rem;
+}
+
+td {
+  text-align: right;
+}
+
+button {
+  margin-top: 10px;
+  cursor: pointer;
+  padding: 5px 10px;
+  color: white;
+  border: none;
+  border-radius: 5px;
+  min-width: 130px;
+}
+
+[type="submit"] {
+  background-color: #0f9d58;
+}
+
+#reset-button {
+  background-color: #db4437;
+}
+
+footer {
+  margin-block: 1rem;
+}
+
+table {
+  font-variant-numeric: tabular-nums;
+}

--- a/prompt-api-telemetry/telemetry.js
+++ b/prompt-api-telemetry/telemetry.js
@@ -1,0 +1,324 @@
+/**
+ * Copyright 2026 Rakuten Group, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * OpenTelemetry instrumentation for the Prompt API playground.
+ *
+ * Spans follow OpenInference conventions and are exported directly from the browser to an OpenTelemetry Backend via OTLP/HTTP JSON.
+ */
+
+import {
+  trace,
+  context,
+  SpanStatusCode,
+  SpanKind,
+} from "@opentelemetry/api";
+import { resourceFromAttributes } from "@opentelemetry/resources";
+import {
+  BatchSpanProcessor,
+  SimpleSpanProcessor,
+  ConsoleSpanExporter,
+} from "@opentelemetry/sdk-trace-base";
+import { WebTracerProvider } from "@opentelemetry/sdk-trace-web";
+import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http";
+
+const OI = {
+  SPAN_KIND: "openinference.span.kind",
+  INPUT_VALUE: "input.value",
+  INPUT_MIME: "input.mime_type",
+  OUTPUT_VALUE: "output.value",
+  OUTPUT_MIME: "output.mime_type",
+  LLM_SYSTEM: "llm.system",
+  LLM_PROVIDER: "llm.provider",
+  LLM_MODEL: "llm.model_name",
+  LLM_TOKEN_PROMPT: "llm.token_count.prompt",
+  LLM_TOKEN_COMPLETION: "llm.token_count.completion",
+  LLM_TOKEN_TOTAL: "llm.token_count.total",
+  SESSION_ID: "session.id",
+};
+
+const OI_KIND = { LLM: "LLM", CHAIN: "CHAIN" };
+
+const MODEL = {
+  system: "chrome-built-in-ai",
+  provider: "google",
+  model: "gemini-nano",
+};
+
+const TRACER_NAME = "prompt-api-telemetry";
+const TRACER_VERSION = "0.1.0";
+
+let currentProvider = null;
+let tracer = trace.getTracer(TRACER_NAME, TRACER_VERSION);
+
+function flattenMessages(prefix, messages) {
+  const attrs = {};
+  messages.forEach((msg, i) => {
+    attrs[`${prefix}.${i}.message.role`] = msg.role;
+    attrs[`${prefix}.${i}.message.content`] =
+      typeof msg.content === "string" ? msg.content : JSON.stringify(msg.content);
+  });
+  return attrs;
+}
+
+/** @param {{ mode?: "console"|"otlp", serviceName?: string, otlpUrl?: string, otlpHeaders?: Record<string,string>, resourceAttributes?: Record<string,string> }} opts */
+export async function initTelemetry(opts = {}) {
+  const {
+    mode = "otlp",
+    serviceName = "prompt-api-playground",
+    otlpUrl,
+    otlpHeaders,
+    resourceAttributes,
+  } = opts;
+
+  if (currentProvider) {
+    try {
+      await currentProvider.shutdown();
+    } catch (err) {
+      console.warn("[telemetry] shutdown failed:", err);
+    }
+    currentProvider = null;
+  }
+
+  const spanProcessors = [];
+  if (mode === "console") {
+    spanProcessors.push(new SimpleSpanProcessor(new ConsoleSpanExporter()));
+  } else if (mode === "otlp") {
+    if (!otlpUrl) throw new Error("initTelemetry: otlpUrl required");
+    spanProcessors.push(
+      new BatchSpanProcessor(new OTLPTraceExporter({ url: otlpUrl, headers: otlpHeaders ?? {} }))
+    );
+  }
+
+  const provider = new WebTracerProvider({
+    resource: resourceFromAttributes({
+      "service.name": serviceName,
+      "openinference.project.name": serviceName,
+      ...(resourceAttributes ?? {}),
+    }),
+    spanProcessors,
+  });
+
+  provider.register();
+  currentProvider = provider;
+  tracer = provider.getTracer(TRACER_NAME, TRACER_VERSION);
+
+  window.addEventListener("visibilitychange", () => {
+    if (document.visibilityState === "hidden") provider.forceFlush();
+  });
+  window.addEventListener("beforeunload", () => provider.forceFlush());
+
+  return provider;
+}
+
+export async function flushTelemetry() {
+  if (!currentProvider) return;
+  try {
+    await currentProvider.forceFlush();
+  } catch (err) {
+    console.warn("[telemetry] forceFlush failed:", err);
+  }
+}
+
+export async function createInstrumentedSession(options = {}) {
+  return tracer.startActiveSpan(
+    "LanguageModel.create",
+    { kind: SpanKind.CLIENT },
+    async (span) => {
+      const sessionId = crypto.randomUUID();
+      const initialPrompts = options.initialPrompts ?? [];
+      const systemPrompt = initialPrompts.find((p) => p.role === "system")?.content;
+
+      span.setAttributes({
+        [OI.SPAN_KIND]: OI_KIND.CHAIN,
+        [OI.SESSION_ID]: sessionId,
+        [OI.LLM_SYSTEM]: MODEL.system,
+        [OI.LLM_PROVIDER]: MODEL.provider,
+        [OI.LLM_MODEL]: MODEL.model,
+        [OI.INPUT_VALUE]: JSON.stringify(options),
+        [OI.INPUT_MIME]: "application/json",
+      });
+      if (systemPrompt) span.setAttribute("session.system_prompt", systemPrompt);
+
+      try {
+        const session = await LanguageModel.create(options);
+        span.setAttributes({
+          "session.context_window": session.contextWindow ?? session.inputQuota ?? 0,
+        });
+        span.setStatus({ code: SpanStatusCode.OK });
+        return wrapSession(session, { sessionId, systemPrompt });
+      } catch (err) {
+        span.recordException(err);
+        span.setStatus({ code: SpanStatusCode.ERROR, message: String(err?.message ?? err) });
+        throw err;
+      } finally {
+        span.end();
+      }
+    }
+  );
+}
+
+function wrapSession(session, meta) {
+  const state = { ...meta, turnIndex: 0 };
+  return new Proxy(session, {
+    get(target, prop, receiver) {
+      if (prop === "prompt") return (input, opts) => tracedPrompt(target, state, input, opts);
+      if (prop === "promptStreaming") {
+        return (input, opts) => tracedPromptStreaming(target, state, input, opts);
+      }
+      if (prop === "destroy") {
+        return () => {
+          try {
+            return target.destroy();
+          } finally {
+            const span = tracer.startSpan("LanguageModel.destroy");
+            span.setAttributes({ [OI.SPAN_KIND]: OI_KIND.CHAIN, [OI.SESSION_ID]: state.sessionId });
+            span.end();
+          }
+        };
+      }
+      // Native getters (contextWindow, contextUsage, …) require the real session
+      // as `this`. Using the Proxy as receiver causes "Illegal invocation".
+      const value = Reflect.get(target, prop, target);
+      return typeof value === "function" ? value.bind(target) : value;
+    },
+  });
+}
+
+async function tracedPrompt(session, state, input, opts) {
+  state.turnIndex += 1;
+  return tracer.startActiveSpan(
+    "LanguageModel.prompt",
+    { kind: SpanKind.CLIENT },
+    async (span) => {
+      const messages = buildMessages(state.systemPrompt, input);
+      const tokensBefore = readContextUsage(session);
+
+      span.setAttributes({
+        [OI.SPAN_KIND]: OI_KIND.LLM,
+        [OI.SESSION_ID]: state.sessionId,
+        [OI.LLM_SYSTEM]: MODEL.system,
+        [OI.LLM_PROVIDER]: MODEL.provider,
+        [OI.LLM_MODEL]: MODEL.model,
+        [OI.INPUT_VALUE]: typeof input === "string" ? input : JSON.stringify(input),
+        [OI.INPUT_MIME]: typeof input === "string" ? "text/plain" : "application/json",
+        "llm.turn_index": state.turnIndex,
+        ...flattenMessages("llm.input_messages", messages),
+      });
+
+      try {
+        const result = await session.prompt(input, opts);
+        const tokensAfter = readContextUsage(session);
+        span.setAttributes({
+          [OI.OUTPUT_VALUE]: result,
+          [OI.OUTPUT_MIME]: "text/plain",
+          ...flattenMessages("llm.output_messages", [{ role: "assistant", content: result }]),
+          ...tokenAttrs(tokensBefore, tokensAfter),
+        });
+        span.setStatus({ code: SpanStatusCode.OK });
+        return result;
+      } catch (err) {
+        span.recordException(err);
+        span.setStatus({ code: SpanStatusCode.ERROR, message: String(err?.message ?? err) });
+        throw err;
+      } finally {
+        span.end();
+      }
+    }
+  );
+}
+
+function tracedPromptStreaming(session, state, input, opts) {
+  state.turnIndex += 1;
+  const messages = buildMessages(state.systemPrompt, input);
+  const tokensBefore = readContextUsage(session);
+
+  const span = tracer.startSpan("LanguageModel.promptStreaming", { kind: SpanKind.CLIENT }, context.active());
+  span.setAttributes({
+    [OI.SPAN_KIND]: OI_KIND.LLM,
+    [OI.SESSION_ID]: state.sessionId,
+    [OI.LLM_SYSTEM]: MODEL.system,
+    [OI.LLM_PROVIDER]: MODEL.provider,
+    [OI.LLM_MODEL]: MODEL.model,
+    [OI.INPUT_VALUE]: typeof input === "string" ? input : JSON.stringify(input),
+    [OI.INPUT_MIME]: typeof input === "string" ? "text/plain" : "application/json",
+    "llm.turn_index": state.turnIndex,
+    "llm.streaming": true,
+    ...flattenMessages("llm.input_messages", messages),
+  });
+
+  let underlying;
+  try {
+    underlying = session.promptStreaming(input, opts);
+  } catch (err) {
+    span.recordException(err);
+    span.setStatus({ code: SpanStatusCode.ERROR, message: String(err?.message ?? err) });
+    span.end();
+    throw err;
+  }
+
+  const startedAt = performance.now();
+  let firstChunkAt = null;
+  let chunkCount = 0;
+  let fullText = "";
+  let previousChunk = "";
+
+  return new ReadableStream({
+    async start(controller) {
+      try {
+        for await (const chunk of underlying) {
+          chunkCount += 1;
+          if (firstChunkAt === null) {
+            firstChunkAt = performance.now();
+            span.addEvent("llm.first_token", {
+              "llm.time_to_first_token_ms": firstChunkAt - startedAt,
+            });
+          }
+          const delta = chunk.startsWith(previousChunk) ? chunk.slice(previousChunk.length) : chunk;
+          fullText += delta;
+          previousChunk = chunk;
+          controller.enqueue(chunk);
+        }
+        span.setAttributes({
+          [OI.OUTPUT_VALUE]: fullText,
+          [OI.OUTPUT_MIME]: "text/plain",
+          "llm.chunk_count": chunkCount,
+          "llm.duration_ms": performance.now() - startedAt,
+          ...flattenMessages("llm.output_messages", [{ role: "assistant", content: fullText }]),
+          ...tokenAttrs(tokensBefore, readContextUsage(session)),
+        });
+        span.setStatus({ code: SpanStatusCode.OK });
+        controller.close();
+      } catch (err) {
+        span.recordException(err);
+        span.setStatus({ code: SpanStatusCode.ERROR, message: String(err?.message ?? err) });
+        controller.error(err);
+      } finally {
+        span.end();
+      }
+    },
+  });
+}
+
+function buildMessages(systemPrompt, input) {
+  const messages = [];
+  if (systemPrompt) messages.push({ role: "system", content: systemPrompt });
+  if (typeof input === "string") messages.push({ role: "user", content: input });
+  else if (Array.isArray(input)) messages.push(...input);
+  else if (input && typeof input === "object") messages.push(input);
+  return messages;
+}
+
+function readContextUsage(session) {
+  return session.contextUsage ?? session.inputUsage ?? session.tokensSoFar ?? 0;
+}
+
+function tokenAttrs(before, after) {
+  const total = Math.max(0, Math.round(after));
+  const delta = Math.max(0, Math.round(after - before));
+  return {
+    [OI.LLM_TOKEN_TOTAL]: total,
+    [OI.LLM_TOKEN_PROMPT]: Math.max(0, Math.round(before)),
+    [OI.LLM_TOKEN_COMPLETION]: delta,
+  };
+}


### PR DESCRIPTION
## Summary
Adds prompt-api-telemetry, a standalone PoC for observability on Chrome's built-in Prompt API.

## Motivation
Server-side GenAI teams already use OpenTelemetry to observe behavior, evaluate quality, and debug failures. Built-in AI runs in the browser with no backend, so those stacks don't apply out of the box — without traces, teams can't close the loop on prompt quality, latency, or errors for on-device inference.

## What this is 
This demo shows we can instrument the Prompt API in the client and export [OpenInference](https://arize-ai.github.io/openinference/spec/) traces to the same OTLP backends used for server-side GenAI (Langfuse, LangSmith). It's a copy of prompt-api-playground with minimal changes: it instruments LanguageModel.create, promptStreaming, and destroy, and exports spans directly from the browser via OTLP/HTTP JSON — no app backend.

Only config.example.js is committed; credentials go in a local gitignored config.js.