### PR TITLE
Add multilingual SemanticEmbedder search demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Others showcase generic client-side AI using Transformers.js or Google's Gemma m
 - `prompt-api-playground`: Showcases Chrome's built-in experimental Prompt API.
 - `summarization-api-playground`: Showcases Chrome's built-in experimental Summarization API.
 - `speech-api-playground`: Showcases the Web Speech API for continuous speech recognition, interim results, and local on-device models.
+- `semantic-embedder-multilingual-search`: Uses Chrome Canary's experimental SemanticEmbedder API to search a Spanish document with queries written in other languages, without translating the text.
 - `perf-client-side-gemma-worker`: Showcases web performance/UX tips for client-side Gen AI, based on a web worker. Uses an LLM (Google's Gemma 2) through MediaPipe.
 - `right-click-for-superpowers`: Shows how to add utility to a webpage utilizing an LLM (Google's Gemma 2B) to perform common useful tasks like summarisation, translation, or defining words or phrases in a manner that is then easier to understand.
 - `product-reviews`: Includes client-side sentiment analysis, toxicity, and rating assesment of a product review. Showcased at I/O 2024. Uses an LLM (Google's Gemma 2B) through MediaPipe, and toxicity models from Transformers.js.

--- a/semantic-embedder-multilingual-search/README.md
+++ b/semantic-embedder-multilingual-search/README.md
@@ -1,0 +1,26 @@
+# Multilingual semantic search
+
+This demo uses Chrome's experimental built-in `SemanticEmbedder` API to search
+a Spanish travel guide with queries written in English, German, Japanese, or
+any other language. It compares meaning directly and does not translate the
+text.
+
+## Requirements
+
+- A recent desktop Chrome Canary.
+- `chrome://flags/#semantic-embedder-api` set to **Enabled**.
+- A secure context such as `http://localhost`.
+
+## Run locally
+
+From the repository root:
+
+```sh
+npx http-server semantic-embedder-multilingual-search -p 8000
+```
+
+Open <http://localhost:8000> in Chrome Canary.
+
+The document passages are embedded with `retrieval-document`. The query is
+embedded with `retrieval-query`. A small cosine-similarity function selects the
+closest passage.

--- a/semantic-embedder-multilingual-search/index.html
+++ b/semantic-embedder-multilingual-search/index.html
@@ -1,0 +1,91 @@
+<!--
+  Copyright 2026 Google LLC
+  SPDX-License-Identifier: Apache-2.0
+-->
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="color-scheme" content="dark light" />
+    <link rel="icon" href="data:," />
+    <link rel="stylesheet" href="style.css" />
+    <script type="module" src="script.js"></script>
+    <title>Search a Spanish document in any language</title>
+  </head>
+  <body>
+    <main>
+      <h1>Search a Spanish document in any language</h1>
+      <p>
+        Type a question in another language. SemanticEmbedder highlights the
+        closest Spanish passage by meaning, without translating the text.
+      </p>
+
+      <p id="status" class="status" aria-live="polite">
+        Checking SemanticEmbedder…
+      </p>
+      <progress id="progress" max="1" value="0" hidden></progress>
+
+      <form id="search-form">
+        <label for="query">Ask in any language</label>
+        <div class="search-row">
+          <input
+            id="query"
+            type="search"
+            value="How do I get from the airport to the city centre?"
+            required
+          />
+          <button type="submit" disabled>Search</button>
+        </div>
+      </form>
+
+      <section class="document" aria-labelledby="document-title" lang="es">
+        <h2 id="document-title">Guía práctica de Madrid</h2>
+
+        <article data-passage>
+          <h3>Desde el aeropuerto</h3>
+          <p>
+            El tren exprés conecta el aeropuerto con el centro de Madrid cada
+            quince minutos. El trayecto dura aproximadamente media hora y los
+            billetes se venden en las máquinas de la estación.
+          </p>
+        </article>
+
+        <article data-passage>
+          <h3>Museos</h3>
+          <p>
+            Muchos museos ofrecen entrada gratuita durante las dos últimas horas
+            del día. Conviene consultar el horario oficial antes de la visita
+            porque puede cambiar en días festivos.
+          </p>
+        </article>
+
+        <article data-passage>
+          <h3>Transporte público</h3>
+          <p>
+            Para utilizar el metro y los autobuses necesitas una tarjeta
+            recargable. Puedes comprarla en cualquier estación de metro y añadir
+            viajes en las máquinas automáticas.
+          </p>
+        </article>
+
+        <article data-passage>
+          <h3>Farmacias de guardia</h3>
+          <p>
+            Las farmacias de guardia permanecen abiertas por la noche. Cada
+            farmacia cerrada muestra en la puerta la dirección de la farmacia de
+            guardia más cercana.
+          </p>
+        </article>
+      </section>
+
+      <details>
+        <summary>Canary setup</summary>
+        <p>
+          Enable <code>chrome://flags/#semantic-embedder-api</code> and relaunch
+          Chrome Canary. The first search may download the on-device model.
+        </p>
+      </details>
+    </main>
+  </body>
+</html>

--- a/semantic-embedder-multilingual-search/script.js
+++ b/semantic-embedder-multilingual-search/script.js
@@ -1,0 +1,112 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+const form = document.querySelector("#search-form");
+const queryInput = document.querySelector("#query");
+const button = form.querySelector("button");
+const status = document.querySelector("#status");
+const progress = document.querySelector("#progress");
+const passages = [...document.querySelectorAll("[data-passage]")];
+
+let embedder;
+let passageVectors;
+
+const passageText = (passage) =>
+  `${passage.querySelector("h3").textContent}\n${passage.querySelector("p").textContent}`;
+
+const checkAvailability = async () => {
+  if (!("SemanticEmbedder" in self)) {
+    status.textContent =
+      "SemanticEmbedder is not available. Open this page in Chrome Canary and enable the flag below.";
+    return;
+  }
+
+  const availability = await self.SemanticEmbedder.availability();
+  status.textContent =
+    availability === "available"
+      ? "SemanticEmbedder is ready."
+      : `SemanticEmbedder is ${availability}. The first search may download the model.`;
+  button.disabled = availability === "unavailable";
+};
+
+const getEmbedder = async () => {
+  if (embedder) {
+    return embedder;
+  }
+
+  progress.hidden = false;
+  status.textContent = "Preparing the model…";
+  embedder = await self.SemanticEmbedder.create({
+    monitor(monitor) {
+      monitor.addEventListener("downloadprogress", (event) => {
+        progress.value = event.loaded;
+        status.textContent = `Downloading model: ${Math.round(event.loaded * 100)}%`;
+      });
+    },
+  });
+  progress.hidden = true;
+  return embedder;
+};
+
+const cosineSimilarity = (a, b) => {
+  let dotProduct = 0;
+  let normA = 0;
+  let normB = 0;
+
+  for (let index = 0; index < a.length; index += 1) {
+    dotProduct += a[index] * b[index];
+    normA += a[index] * a[index];
+    normB += b[index] * b[index];
+  }
+
+  return dotProduct / (Math.sqrt(normA) * Math.sqrt(normB));
+};
+
+const search = async (query) => {
+  const session = await getEmbedder();
+
+  if (!passageVectors) {
+    status.textContent = "Reading the Spanish document…";
+    const response = await session.embed(passages.map(passageText), {
+      taskType: "retrieval-document",
+    });
+    passageVectors = response.embeddings.map((embedding) => embedding.values);
+  }
+
+  status.textContent = "Searching…";
+  const queryResponse = await session.embed(query, {
+    taskType: "retrieval-query",
+  });
+  const queryVector = queryResponse.embeddings[0].values;
+
+  const bestMatch = passages
+    .map((passage, index) => ({
+      passage,
+      score: cosineSimilarity(queryVector, passageVectors[index]),
+    }))
+    .sort((a, b) => b.score - a.score)[0].passage;
+
+  passages.forEach((passage) => passage.removeAttribute("data-match"));
+  bestMatch.dataset.match = "";
+  bestMatch.scrollIntoView({ behavior: "smooth", block: "center" });
+  status.textContent = `Best match: ${bestMatch.querySelector("h3").textContent}`;
+};
+
+form.addEventListener("submit", async (event) => {
+  event.preventDefault();
+  button.disabled = true;
+
+  try {
+    await search(queryInput.value.trim());
+  } catch (error) {
+    status.textContent = `Search failed: ${error.message}`;
+  } finally {
+    button.disabled = false;
+  }
+});
+
+self.addEventListener("pagehide", () => embedder?.destroy());
+
+await checkAvailability();

--- a/semantic-embedder-multilingual-search/style.css
+++ b/semantic-embedder-multilingual-search/style.css
@@ -1,0 +1,139 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+:root {
+  color-scheme: dark light;
+  font-family: system-ui, sans-serif;
+  --accent: light-dark(#0b57d0, #a8c7fa);
+  --surface: light-dark(#f4f7fc, #202124);
+  --border: light-dark(#c7c7c7, #5f6368);
+  --muted: light-dark(#5f6368, #bdc1c6);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+}
+
+main {
+  width: min(760px, calc(100% - 2rem));
+  margin: 3rem auto;
+}
+
+h1 {
+  margin-block-end: 0.5rem;
+  font-size: clamp(2rem, 6vw, 3.5rem);
+  line-height: 1;
+  letter-spacing: -0.04em;
+}
+
+h2,
+h3,
+p {
+  margin-block-start: 0;
+}
+
+main > p:first-of-type {
+  max-width: 65ch;
+  color: var(--muted);
+  line-height: 1.5;
+}
+
+.status {
+  margin-block: 1.5rem 0.5rem;
+  font-weight: 650;
+}
+
+progress {
+  width: 100%;
+  accent-color: var(--accent);
+}
+
+form {
+  display: grid;
+  gap: 0.5rem;
+  margin-block: 2rem;
+  padding: 1rem;
+  border-radius: 0.75rem;
+  background: var(--surface);
+}
+
+label {
+  font-weight: 700;
+}
+
+input,
+button {
+  min-height: 2.75rem;
+  padding-inline: 0.75rem;
+  border: 1px solid var(--border);
+  border-radius: 0.5rem;
+  font: inherit;
+}
+
+.search-row {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 0.5rem;
+}
+
+button {
+  padding-inline: 1.5rem;
+  border-color: var(--accent);
+  background: var(--accent);
+  color: light-dark(white, #062e6f);
+  font-weight: 700;
+  cursor: pointer;
+}
+
+button:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.document {
+  margin-block: 2rem;
+}
+
+.document article {
+  padding: 1rem;
+  border-inline-start: 4px solid transparent;
+}
+
+.document article + article {
+  border-block-start: 1px solid var(--border);
+}
+
+.document article[data-match] {
+  border-inline-start-color: var(--accent);
+  background: var(--surface);
+}
+
+.document article p {
+  margin-block-end: 0;
+  line-height: 1.55;
+}
+
+details {
+  margin-block-start: 2rem;
+}
+
+summary {
+  cursor: pointer;
+  font-weight: 700;
+}
+
+@media (max-width: 560px) {
+  main {
+    margin-block: 1.5rem;
+  }
+
+  .search-row {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
Fixes #427

  Adds a simple Chrome Canary demo that uses the native SemanticEmbedder API.

  The demo:

  - contains a Spanish document
  - accepts search queries in other languages
  - uses retrieval-document and retrieval-query embeddings
  - highlights the closest Spanish passage
  - runs entirely on-device