### PR TITLE
fix(cos-resource-fetcher): don't fail fetchBlob() on non-LFS URLs

### DIFF
--- a/cos-resource-fetcher/README.md
+++ b/cos-resource-fetcher/README.md
@@ -125,7 +125,7 @@ const blob = await fetchBlob(cdnUrl, {
 | Option       | Type                                                  | Default                                | Description                                                                 |
 | ------------ | ----------------------------------------------------- | -------------------------------------- | --------------------------------------------------------------------------- |
 | `sha256`     | `string`                                              | —                                      | Lowercase hex SHA-256, if already known. Takes precedence over `getSHA256`. |
-| `getSHA256`  | `(url: string) => Promise<string>`                    | [`getHuggingFaceSHA256`](src/index.js) | Derives the SHA-256 at runtime. Only called when `sha256` is not provided.  |
+| `getSHA256`  | `(url: string) => Promise<string \| undefined>`       | [`getHuggingFaceSHA256`](src/index.js) | Derives the SHA-256 at runtime. Only called when `sha256` is not provided. Returning `undefined` (or throwing) falls back to the Cache API path. |
 | `onProgress` | `({ loaded: number, total: number \| null }) => void` | —                                      | Called with byte counts during a network download.                          |
 | `cacheName`  | `string`                                              | `'cos-resource-fetcher'`               | Cache API bucket used by the fallback path.                                 |
 
@@ -142,6 +142,10 @@ const sha256 = await getHuggingFaceSHA256(
 );
 console.log(sha256); // e.g. "3f4a…"
 ```
+
+It resolves to `undefined` when the URL is not a Hugging Face `/resolve/` URL,
+or when the resource is not LFS-backed (small files such as `config.json` are
+served verbatim, with no pointer to parse).
 
 ## Demo
 

--- a/cos-resource-fetcher/package-lock.json
+++ b/cos-resource-fetcher/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cos-resource-fetcher",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cos-resource-fetcher",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "Apache-2.0"
     }
   }

--- a/cos-resource-fetcher/package.json
+++ b/cos-resource-fetcher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cos-resource-fetcher",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Fetch resource blobs via Cross-Origin Storage (COS) with Cache API fallback. Defaults to Hugging Face SHA-256 resolution, but accepts any custom resolver.",
   "type": "module",
   "exports": {

--- a/cos-resource-fetcher/src/index.d.ts
+++ b/cos-resource-fetcher/src/index.d.ts
@@ -23,16 +23,20 @@ export interface FetchBlobOptions {
   sha256?: string;
 
   /**
-   * Returns the lowercase hex SHA-256 for the resource at `url`. Only called
-   * when {@link sha256} is not provided.
+   * Returns the lowercase hex SHA-256 for the resource at `url`, or
+   * `undefined` if it cannot be determined. Only called when {@link sha256} is
+   * not provided.
    *
    * Resolved hashes are cached — in memory for the current session and
    * persistently in the Cache API — so the resolver is only called on the
    * first request for a given URL per origin.
    *
+   * When the resolver returns `undefined` or throws, COS cannot be keyed for
+   * that URL and {@link fetchBlob} falls back to the Cache API path.
+   *
    * Defaults to {@link getHuggingFaceSHA256}.
    */
-  getSHA256?: (url: string) => Promise<string>;
+  getSHA256?: (url: string) => Promise<string | undefined>;
 
   /**
    * Called with running byte counts whenever a network fetch is in progress.
@@ -53,12 +57,17 @@ export interface FetchBlobOptions {
  * Extracts the SHA-256 hash for a Hugging Face resource by fetching its Git
  * LFS pointer file. Works with any Hugging Face `/resolve/` URL.
  *
+ * Resolves to `undefined` when no pointer applies: the URL is not a Hugging
+ * Face `/resolve/` URL, or the resource is not LFS-backed (small files such as
+ * `config.json` are served verbatim by `/raw/`, with no pointer to parse).
+ *
  * @param resolveUrl - A Hugging Face `/resolve/` URL.
- * @returns Lowercase hex SHA-256 string.
+ * @returns Lowercase hex SHA-256 string, or `undefined` if the resource has no
+ *   LFS pointer.
  */
 export declare function getHuggingFaceSHA256(
   resolveUrl: string
-): Promise<string>;
+): Promise<string | undefined>;
 
 /**
  * Fetches a resource as a `Blob` using Cross-Origin Storage (COS) when

--- a/cos-resource-fetcher/src/index.js
+++ b/cos-resource-fetcher/src/index.js
@@ -21,12 +21,16 @@ async function resolveSha256(url, getSHA256) {
   }
 
   const hash = await getSHA256(url);
+  // Also memoizes a negative result, so a URL with no resolvable hash costs at
+  // most one resolver call per session.
   sha256Memory.set(url, hash);
-  // Fire-and-forget; failure is non-fatal (in-memory copy still valid for this session)
-  cache.put(
-    url,
-    new Response(hash, { headers: { 'Content-Type': 'text/plain' } })
-  );
+  if (hash) {
+    // Fire-and-forget; failure is non-fatal (in-memory copy still valid for this session)
+    cache.put(
+      url,
+      new Response(hash, { headers: { 'Content-Type': 'text/plain' } })
+    );
+  }
   return hash;
 }
 
@@ -35,17 +39,26 @@ async function resolveSha256(url, getSHA256) {
  * pointer. The /raw/ endpoint returns the pointer; /resolve/ returns the actual
  * bytes — swapping that path segment is sufficient.
  *
+ * Returns `undefined` when no pointer applies: the URL is not a Hugging Face
+ * /resolve/ URL, or the resource is not LFS-backed (small files such as
+ * config.json are served verbatim by /raw/, with no pointer to parse). Callers
+ * should read that as "COS is not usable for this URL" rather than as an error.
+ *
  * @param {string} resolveUrl - A Hugging Face /resolve/ URL
- * @returns {Promise<string>} Lowercase hex SHA-256 string
+ * @returns {Promise<string|undefined>} Lowercase hex SHA-256 string, or
+ *   `undefined` if the resource has no LFS pointer
  */
 export async function getHuggingFaceSHA256(resolveUrl) {
+  // Without /resolve/ the rewrite below is a no-op, and we would download the
+  // resource itself just to fail at parsing it as a pointer.
+  if (!resolveUrl.includes('/resolve/')) return undefined;
+
   const rawUrl = resolveUrl.replace('/resolve/', '/raw/');
   const res = await fetch(rawUrl);
   if (!res.ok) throw new Error(`LFS pointer fetch failed: ${res.status}`);
   const text = await res.text();
   const match = text.match(/^oid sha256:([0-9a-f]{64})$/m);
-  if (!match) throw new Error('SHA-256 not found in LFS pointer');
-  return match[1];
+  return match ? match[1] : undefined;
 }
 
 /**
@@ -146,9 +159,11 @@ async function fetchViaCache(url, { onProgress, cacheName }) {
  * @param {string} [options.sha256]
  *   Lowercase hex SHA-256 of the resource, if already known. Takes precedence
  *   over `getSHA256`.
- * @param {(url: string) => Promise<string>} [options.getSHA256]
- *   Returns the lowercase hex SHA-256 for the resource at `url`. Only called
- *   when `sha256` is not provided. Defaults to {@link getHuggingFaceSHA256}.
+ * @param {(url: string) => Promise<string|undefined>} [options.getSHA256]
+ *   Returns the lowercase hex SHA-256 for the resource at `url`, or `undefined`
+ *   if it cannot be determined. Only called when `sha256` is not provided.
+ *   Defaults to {@link getHuggingFaceSHA256}. When no hash is available the
+ *   fetch falls back to the Cache API path instead of failing.
  * @param {(progress: { loaded: number, total: number | null }) => void} [options.onProgress]
  *   Called with running byte counts whenever a network fetch is in progress.
  * @param {string} [options.cacheName]
@@ -165,12 +180,23 @@ export async function fetchBlob(url, options = {}) {
   } = options;
 
   if ('crossOriginStorage' in navigator) {
-    try {
-      const sha256 = directSha256 ?? (await resolveSha256(url, getSHA256));
-      return await fetchViaCOS(url, { sha256, onProgress });
-    } catch (err) {
-      if (err.name !== 'NotAllowedError') throw err;
-      // COS permission denied by user — fall through to Cache API
+    let sha256 = directSha256;
+    if (!sha256) {
+      try {
+        sha256 = await resolveSha256(url, getSHA256);
+      } catch {
+        // Hash resolution failed (pointer fetch errored, custom resolver threw…).
+        // COS is keyed by hash, so it is unusable here — fall through rather
+        // than failing a fetch the Cache API path can still serve.
+      }
+    }
+    if (sha256) {
+      try {
+        return await fetchViaCOS(url, { sha256, onProgress });
+      } catch (err) {
+        if (err.name !== 'NotAllowedError') throw err;
+        // COS permission denied by user — fall through to Cache API
+      }
     }
   }
 


### PR DESCRIPTION
## Problem

`getHuggingFaceSHA256()` rewrites `/resolve/` to `/raw/` without first checking that the URL actually contains `/resolve/`:

```js
const rawUrl = resolveUrl.replace('/resolve/', '/raw/');   // no-op if absent
const res = await fetch(rawUrl);
```

When the segment is absent the rewrite is a silent no-op, so we fetch **the resource itself** and run `.text()` over it, only to fail at parsing it as an LFS pointer. For a model weight that means downloading the entire file and UTF-8-decoding it just to throw. The same applies to Hugging Face URLs that aren't LFS-backed — `/raw/` serves small files like `config.json` verbatim, with no pointer to parse.

It compounds in `fetchBlob()`, which only swallows `NotAllowedError`, so the throw propagates instead of falling through to the Cache API path. Net effect: **having the COS extension installed turns a working fetch into a thrown error for any non-LFS URL**, while the identical call succeeds in a browser without it.

The demo only ever passes HF `/resolve/` URLs so it doesn't bite there, but `src/` ships as a reusable package with `index.d.ts`, a `cacheName` option and a pluggable `getSHA256`, so this is reachable by design.

For reference, every other COS integration guards this before rewriting — [wllama](https://github.com/ngxson/wllama/blob/master/src/huggingface.ts#L142) (`if (!url.includes('/resolve/')) return undefined;`), [transformers.js](https://github.com/huggingface/transformers.js/blob/main/packages/transformers/src/utils/cache/CrossOriginStorageCache.js), and [tvm](https://github.com/apache/tvm/blob/main/web/src/artifact_cache.ts).

## Changes

- Guard on `/resolve/` before the rewrite.
- Return `undefined` instead of throwing when there is no pointer to parse — "not LFS-backed" is a normal outcome, not a failure. Genuine network/HTTP errors still throw.
- In `fetchBlob()`, treat an unresolvable hash as "COS is unusable for this URL" and fall back to the Cache API. Errors from COS itself are still rethrown unless they're `NotAllowedError`, as before.
- Memoize negative lookups, so an unresolvable URL costs at most one resolver call per session, and skip persisting empty hashes to the Cache API.
- Docs (`index.d.ts`, JSDoc, README) updated for the `Promise<string | undefined>` return type; minor version bump to 0.3.0.

## Notes

The hash parsing itself was already correct and is untouched — `/^oid sha256:([0-9a-f]{64})$/m` is anchored, lowercase-only and length-checked, which is stricter than the equivalents in transformers.js and tvm.

`getHuggingFaceSHA256`'s signature widens from `Promise<string>` to `Promise<string | undefined>`, hence the minor bump rather than a patch.