### PR TITLE
Add semantic embedder demos

### DIFF
--- a/prompt-api-polyfill/index.html
+++ b/prompt-api-polyfill/index.html
@@ -1,3 +1,7 @@
+<!--
+  Copyright 2026 Google LLC
+  SPDX-License-Identifier: Apache-2.0
+-->
 <!doctype html>
 <html lang="en">
 <head>

--- a/semantic-embedder/README.md
+++ b/semantic-embedder/README.md
@@ -1,0 +1,42 @@
+# SemanticEmbedder API Prototypes
+
+This directory contains a suite of prototypes demonstrating the capabilities of
+the Chrome built-in AI `SemanticEmbedder API`.
+
+## Requirements
+
+You must be using Chrome Canary (version >= 152.0.7943.0) and you MUST enable
+the following flag to test these features:
+
+1. Navigate to: `chrome://flags/#semantic-embedder-api` and Enable it.
+2. Relaunch the browser.
+
+*Note: For developers exploring the code, the core embedding logic, API calls, and cosine similarity computations are implemented directly inside each app's respective script (e.g., `note_search.js`, `comment_moderator.js`, `docs_rag.js`) without external wrappers, letting you directly read the raw logic of each app.*
+
+## How to Run the Demo Locally
+
+Because the prototypes use ES6 modules, they must be served over HTTP rather
+than opened as raw `file://` URIs. The easiest way to do this is using Python's
+built-in HTTP server.
+
+1. Open your terminal and navigate to this directory.
+2. Run the following command:
+
+```bash
+python3 -m http.server 8000
+```
+
+3. Open your browser and navigate to: [http://localhost:8000](http://localhost:8000)
+
+## Prototypes
+
+1. **Semantic Note Search (`note_search.html`)**: Demonstrates simple on-device
+   vectorization and cosine similarity search over small sensitive texts without
+   sending data server-side.
+2. **Toxic Comment Moderator (`comment_moderator.html`)**: Nudges users away
+   from toxic behavior using zero-latency checking against pre-computed toxic
+   embedding anchors.
+3. **Documentation RAG (`docs_rag.html`)**: Demonstrates how you can use both
+   the Semantic Embedder API for context retrieval, and the Prompt API for
+   synthesis to provide a RAG chatbot exclusively on the client side, requiring
+   zero server-side databases or AI models.

--- a/semantic-embedder/comment_moderator.html
+++ b/semantic-embedder/comment_moderator.html
@@ -1,0 +1,62 @@
+<!--
+  Copyright 2026 Google LLC
+  SPDX-License-Identifier: Apache-2.0
+-->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Comment Moderator Prototype</title>
+    <link rel="stylesheet" href="style.css">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600&family=Outfit:wght@400;600&display=swap" rel="stylesheet">
+</head>
+<body>
+    <div class="container">
+        <header>
+            <h1>Toxic Comment Moderator</h1>
+            <p>Real-time moderation to nudge users away from toxic behavior before they post.</p>
+        </header>
+
+        <div class="status-bar" id="statusBar">
+            Checking API availability...
+        </div>
+
+        <nav class="tabs-nav">
+             <a href="index.html" class="tab-btn">Home</a>
+             <a href="note_search.html" class="tab-btn">Note Search</a>
+             <a href="comment_moderator.html" class="tab-btn active">Comment Moderator</a>
+             <a href="docs_rag.html" class="tab-btn">Docs RAG</a>
+        </nav>
+
+        <main>
+            <div class="tab-content active" style="display: block;">
+                <section class="moderator-section">
+                    <div class="forum-container">
+                        <div class="mock-post">
+                            <h3>Mock Blog Post: The Future of AI</h3>
+                            <p>This is a mock blog post to simulate a community forum environment. Feel free to leave a comment below.</p>
+                        </div>
+                        <div class="comment-box-container">
+                            <textarea id="commentInput" placeholder="Type your comment here..."></textarea>
+                            <div id="moderationWarning" class="moderation-warning" style="display:none;">
+                                ⚠️ This comment seems a bit aggressive. Consider rephrasing before posting.
+                            </div>
+                            <div id="moderationStats" class="moderation-stats" style="display:none;">
+                                <strong>Top matches:</strong>
+                                <ul id="moderationStatsList"></ul>
+                            </div>
+                            <button id="postCommentBtn">Post Comment</button>
+                        </div>
+                        <div class="comments-list">
+                        </div>
+                    </div>
+                </section>
+            </div>
+        </main>
+    </div>
+    <script type="module" src="comment_moderator.js"></script>
+</body>
+</html>

--- a/semantic-embedder/comment_moderator.js
+++ b/semantic-embedder/comment_moderator.js
@@ -1,0 +1,162 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// comment_moderator.js
+import { initializeApp, escapeHtml, debounce } from './shared_ui.js';
+import { cosineSimilarity } from './utils.js';
+
+
+const statusBar = document.getElementById('statusBar');
+const commentInput = document.getElementById('commentInput');
+const moderationWarning = document.getElementById('moderationWarning');
+const postCommentBtn = document.getElementById('postCommentBtn');
+const moderationStats = document.getElementById('moderationStats');
+const moderationStatsList = document.getElementById('moderationStatsList');
+
+let embedder = null;
+let toxicEmbeddings = [];
+
+const toxicAnchors = [
+    "You are stupid", "This is garbage", "Go to hell", "I hate you", "Shut up",
+    "You are an absolute idiot", "Nobody cares what you think", "Delete your account immediately",
+    "You are completely worthless", "This is the worst opinion I have ever seen",
+    "You are so dumb it hurts", "What a pathetic joke you are", "You have no idea what you are talking about",
+    "Stop posting this trash", "You should be ashamed of yourself", "This is total rubbish",
+    "You are a terrible person", "Go away and never come back", "You are a moron",
+    "This is completely useless", "You are out of your mind", "What a ridiculously bad take",
+    "You are a complete failure", "This is toxic waste", "You are nothing but a troll",
+    "Stop spreading your idiocy", "You are clearly brain dead", "No one will ever love you",
+    "This is offensive and disgusting", "You are a disgusting human being", "I hope you lose your job",
+    "You are incredibly foolish", "You have the intelligence of a rock", "This is absolute nonsense",
+    "You are a complete joke", "I am sick of reading your garbage", "You are a waste of space",
+    "This makes me want to vomit", "You are delusional", "Please stop talking forever",
+    "You are the definition of stupidity", "This is completely brainless", "You are a miserable person",
+    "Why are you so dumb", "You are a clown", "This is dog water", "You are so ignorant",
+    "I despise everything you say", "You are a disgrace", "This is utterly pathetic",
+    "You are completely incompetent", "Stop embarrassing yourself", "You are a lunatic",
+    "This is pure trash", "You are a hypocrite", "I cannot stand you", "You are a liar and a cheat",
+    "This is incredibly stupid", "You are a massive failure", "Nobody likes you",
+    "You are making a fool of yourself", "This is hilariously bad", "You are a fake",
+    "You have no brain cells", "This is a disaster", "You are entirely clueless",
+    "I hope bad things happen to you", "You are a menace", "This is verbal diarrhea",
+    "You are completely irrelevant", "Stop wasting our time", "You are a loser",
+    "This is so annoying", "You are a terrible writer", "Your brain is broken",
+    "This is a nightmare", "You are a pest", "Go cry about it", "You are deeply flawed",
+    "This is completely invalid", "You are a complete hack", "I pity anyone who knows you",
+    "You are a fraud", "This is absolute filth", "You are painfully unaware",
+    "Stop whining like a baby", "You are a joke of a human", "This is a monstrosity",
+    "You are completely unhinged", "Nobody asked for your opinion", "You are a degenerate",
+    "This is fundamentally broken", "You are a sociopath", "Stop ruining this community",
+    "You are a massive disappointment", "This is garbage tier", "You are a fool",
+    "I wish you would just disappear", "You are incredibly annoying", "This is a complete mess"
+];
+
+async function init() {
+    embedder = await initializeApp(statusBar);
+    if (!embedder) return;
+    
+    // Precompute toxic embeddings
+    try {
+        const cacheKey = 'toxic_embeddings_v1';
+        const cached = localStorage.getItem(cacheKey);
+        const startToxic = performance.now();
+        
+        if (cached) {
+            toxicEmbeddings = JSON.parse(cached);
+            statusBar.textContent = `Ready. (Loaded from cache in ${(performance.now() - startToxic).toFixed(0)}ms)`;
+            statusBar.className = "status-bar ready";
+        } else {
+            statusBar.textContent = "Pre-computing embeddings for moderation...";
+            const toxicChunkSize = 5;
+            for (let i = 0; i < toxicAnchors.length; i += toxicChunkSize) {
+                const chunk = toxicAnchors.slice(i, i + toxicChunkSize);
+                const result = await embedder.embed(chunk);
+                result.embeddings.forEach(emb => {
+                    toxicEmbeddings.push(Array.from(emb.values));
+                });
+                
+                const percent = Math.round(((i + chunk.length) / toxicAnchors.length) * 100);
+                statusBar.textContent = `Pre-computing embeddings... ${percent}%`;
+            }
+            try {
+                localStorage.setItem(cacheKey, JSON.stringify(toxicEmbeddings));
+            } catch (e) { console.warn("Could not cache toxic embeddings", e); }
+            
+            statusBar.textContent = `Ready. (${toxicAnchors.length} toxicity checks loaded in ${(performance.now() - startToxic).toFixed(0)}ms)`;
+            statusBar.className = "status-bar ready";
+        }
+    } catch (e) {
+        console.error("Failed to precompute embeddings:", e);
+        statusBar.textContent = "Error pre-computing: " + e.message;
+        statusBar.className = "status-bar error";
+    }
+    
+    // Setup event listeners
+    if (commentInput) {
+        commentInput.addEventListener('input', (e) => {
+            const text = e.target.value;
+            if (text.endsWith(' ')) {
+                checkModeration(text);
+            } else {
+                debouncedCheck(text);
+            }
+        });
+    }
+}
+
+const checkModeration = async (text) => {
+    if (!embedder || toxicEmbeddings.length === 0) return;
+    
+    if (!text.trim()) {
+        moderationWarning.style.display = 'none';
+        if (moderationStats) moderationStats.style.display = 'none';
+        return;
+    }
+    
+    try {
+        const startTime = performance.now();
+        const result = await embedder.embed([text]);
+        const inputEmbedding = Array.from(result.embeddings[0].values);
+        
+        const endTime = performance.now();
+        const duration = endTime - startTime;
+        
+        const results = [];
+        for (let i = 0; i < toxicAnchors.length; i++) {
+            const sim = cosineSimilarity(inputEmbedding, toxicEmbeddings[i]);
+            results.push({
+                text: toxicAnchors[i],
+                score: !isNaN(sim) ? sim : 0
+            });
+        }
+        
+        results.sort((a, b) => b.score - a.score);
+        const maxSim = results[0].score;
+        
+        if (moderationStatsList) {
+            moderationStatsList.innerHTML = '';
+            results.slice(0, 3).forEach(res => {
+                const li = document.createElement('li');
+                li.innerHTML = `<span>"${escapeHtml(res.text)}"</span> <span>Score: ${res.score.toFixed(4)}</span>`;
+                moderationStatsList.appendChild(li);
+            });
+            if (moderationStats) moderationStats.style.display = 'block';
+        }
+        
+        if (maxSim > 0.8) {
+            moderationWarning.innerHTML = `⚠️ This comment seems a bit aggressive. Consider rephrasing before posting. (Checked in ${duration.toFixed(0)}ms)`;
+            moderationWarning.style.display = 'block';
+        } else {
+            moderationWarning.style.display = 'none';
+        }
+    } catch (error) {
+        console.error("Moderation check failed:", error);
+    }
+};
+
+const debouncedCheck = debounce(checkModeration, 50);
+
+// Start
+init();

--- a/semantic-embedder/demo_assets/bot_rag.txt
+++ b/semantic-embedder/demo_assets/bot_rag.txt
@@ -1,0 +1,5 @@
+What specific model family is the Chrome Text Embedding API designed to target, and what are its sizes?
+
+Why might a developer choose to use Chrome's local Text Embedding API instead of a cloud-based embedding service?
+
+How do I process multiple strings at once using the API, and what parameter should I use to specify that the text being embedded is a document rather than a search query?

--- a/semantic-embedder/demo_assets/moderator.txt
+++ b/semantic-embedder/demo_assets/moderator.txt
@@ -1,0 +1,5 @@
+[FLAGGED] You are incredibly dumb and foolish.
+[FLAGGED] This article is total rubbish and useless.
+[FLAGGED] I strongly despise you and your opinions.
+[FLAGGED] Keep your mouth closed and stop talking.
+[GOOD] This is an interesting perspective, though I don't fully agree with it.

--- a/semantic-embedder/demo_assets/note_content.txt
+++ b/semantic-embedder/demo_assets/note_content.txt
@@ -1,0 +1,7 @@
+# Project Phoenix Status Update
+
+The ACME Corp merger is currently blocked. The legal team found major discrepancies in their Q3 fiscal disclosures. We are looking at a potential $4M liability if we proceed without restructuring the agreement.
+
+In other news, the HR department is planning a team building retreat in Tahoe next month. All expenses will be covered.
+
+The new server migration is scheduled for this weekend. Expect 2 hours of downtime starting Saturday at 2 AM.

--- a/semantic-embedder/demo_assets/note_search.txt
+++ b/semantic-embedder/demo_assets/note_search.txt
@@ -1,0 +1,1 @@
+money problems with the acquisition

--- a/semantic-embedder/docs_rag.html
+++ b/semantic-embedder/docs_rag.html
@@ -1,0 +1,87 @@
+<!--
+  Copyright 2026 Google LLC
+  SPDX-License-Identifier: Apache-2.0
+-->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Docs RAG Prototype</title>
+    <link rel="stylesheet" href="style.css">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600&family=Outfit:wght@400;600&display=swap" rel="stylesheet">
+</head>
+<body>
+    <div class="container">
+        <header>
+            <h1>Documentation RAG</h1>
+            <p>Chat with documentation using the on-device Semantic Embedder API and Prompt API.</p>
+        </header>
+
+        <div class="status-bar" id="statusBar">
+            Checking API availability...
+        </div>
+
+        <nav class="tabs-nav">
+             <a href="index.html" class="tab-btn">Home</a>
+             <a href="note_search.html" class="tab-btn">Note Search</a>
+             <a href="comment_moderator.html" class="tab-btn">Comment Moderator</a>
+             <a href="docs_rag.html" class="tab-btn active">Docs RAG</a>
+        </nav>
+
+        <main>
+            <div class="tab-content active" style="display: block;">
+                <section class="rag-section">
+                    <div class="rag-layout">
+                        <div class="docs-sidebar">
+                            <ul id="mockDocsList" class="mock-docs-list">
+                                <!-- Populated by JS -->
+                            </ul>
+                        </div>
+                        <div class="chat-container">
+                            <div class="chat-header">
+                                <h2>
+                                <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"></path></svg>
+                                RAG Chatbot
+                                </h2>
+                                <div class="status-indicator">
+                                    <span id="ai-status-dot" class="status-dot"></span>
+                                    <span id="ai-status-text">Checking APIs...</span>
+                                </div>
+                            </div>
+                            
+                            <div id="chat-messages" class="chat-messages">
+                                <div class="message bot">
+                                    <div class="message-sender">Chatbot</div>
+                                    <div class="message-bubble">
+                                        Hello! Ask me any questions about the document on the left. My answers are generated purely on-device using Chrome's built-in AI.
+                                    </div>
+                                    <div class="suggested-questions">
+                                        <button type="button" class="suggestion-btn">In what country is Normandy located?</button>
+                                        <button type="button" class="suggestion-btn">When were the Normans in Normandy?</button>
+                                        <button type="button" class="suggestion-btn">Who was the Norse leader?</button>
+                                        <button type="button" class="suggestion-btn">What century did the Normans first gain their separate identity?</button>
+                                        <button type="button" class="suggestion-btn">Who was the duke in the battle of Hastings?</button>
+                                    </div>
+                                </div>
+                            </div>
+                            
+                            <div class="chat-input-area">
+                                <form id="chat-form" class="input-wrapper">
+                                    <input type="text" id="chat-input" class="chat-input" placeholder="Ask a question..." autocomplete="off" disabled>
+                                    <button type="submit" id="chat-send" class="send-btn" disabled>
+                                        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="22" y1="2" x2="11" y2="13"></line><polygon points="22 2 15 22 11 13 2 9 22 2"></polygon></svg>
+                                    </button>
+                                </form>
+                            </div>
+                        </div>
+                    </div>
+                </section>
+            </div>
+        </main>
+    </div>
+    <script type="module" src="docs_rag.js"></script>
+</body>
+</html>

--- a/semantic-embedder/docs_rag.js
+++ b/semantic-embedder/docs_rag.js
@@ -1,0 +1,292 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// docs_rag.js
+import { initializeApp, escapeHtml } from './shared_ui.js';
+import { cosineSimilarity } from './utils.js';
+
+
+const statusBar = document.getElementById('statusBar');
+const statusDot = document.getElementById('ai-status-dot');
+const statusText = document.getElementById('ai-status-text');
+const docsChatInput = document.getElementById('chat-input');
+const docsChatBtn = document.getElementById('chat-send');
+const docsChatResults = document.getElementById('chat-messages');
+const mockDocsList = document.getElementById('mockDocsList');
+
+let embedder = null;
+let languageModelSession = null;
+let docEmbeddings = [];
+
+const rawDocString = `Title: Normans
+The Normans (Norman: Nourmands; French: Normands; Latin: Normanni) were the people who in the 10th and 11th centuries gave their name to Normandy, a region in France. They were descended from Norse ("Norman" comes from "Norseman") raiders and pirates from Denmark, Iceland and Norway who, under their leader Rollo, agreed to swear fealty to King Charles III of West Francia. Through generations of assimilation and mixing with the native Frankish and Roman-Gaulish populations, their descendants would gradually merge with the Carolingian-based cultures of West Francia. The distinct cultural and ethnic identity of the Normans emerged initially in the first half of the 10th century, and it continued to evolve over the succeeding centuries.
+The Norman dynasty had a major political, cultural and military impact on medieval Europe and even the Near East. The Normans were famed for their martial spirit and eventually for their Christian piety, becoming exponents of the Catholic orthodoxy into which they assimilated. They adopted the Gallo-Romance language of the Frankish land they settled, their dialect becoming known as Norman, Normaund or Norman French, an important literary language. The Duchy of Normandy, which they formed by treaty with the French crown, was a great fief of medieval France, and under Richard I of Normandy was forged into a cohesive and formidable principality in feudal tenure. The Normans are noted both for their culture, such as their unique Romanesque architecture and musical traditions, and for their significant military accomplishments and innovations. Norman adventurers founded the Kingdom of Sicily under Roger II after conquering southern Italy on the Saracens and Byzantines, and an expedition on behalf of their duke, William the Conqueror, led to the Norman conquest of England at the Battle of Hastings in 1066. Norman cultural and military influence spread from these new European centres to the Crusader states of the Near East, where their prince Bohemond I founded the Principality of Antioch in the Levant, to Scotland and Wales in Great Britain, to Ireland, and to the coasts of north Africa and the Canary Islands.
+The English name "Normans" comes from the French words Normans/Normanz, plural of Normant, modern French normand, which is itself borrowed from Old Low Franconian Nortmann "Northman" or directly from Old Norse Norðmaðr, Latinized variously as Nortmannus, Normannus, or Nordmannus (recorded in Medieval Latin, 9th century) to mean "Norseman, Viking".`;
+
+// Emulating VectorStore's chunking strategy (maxChunkSizeTokens: 128, chunkOverlapTokens: 20)
+// Assuming 1 token ~= 0.75 words for Embedding Gemma 300M Model
+// 128 * 0.75 = 96 words max chunk size. 20 * 0.75 = 15 words overlap.
+function chunkText(text, maxWords = 50, overlapWords = 7) {
+    const words = text.split(/\s+/);
+    const chunks = [];
+    for (let i = 0; i < words.length; ) {
+        const chunk = words.slice(i, i + maxWords).join(" ");
+        chunks.push(chunk);
+        if (i + maxWords >= words.length) {
+            break;
+        }
+        i += (maxWords - overlapWords);
+    }
+    return chunks;
+}
+
+const mockDocs = chunkText(rawDocString);
+
+async function init() {
+    // Populate UI right away
+    if (mockDocsList) {
+        let docsHtml = '<div class="doc-container">';
+        docsHtml += '<h1 style="font-size: 1.2rem; margin-bottom: 0.5rem; color: var(--primary-color);">Normans (from SQuAD 2.0)</h1>';
+        docsHtml += `<div style="background: rgba(255,255,255,0.02); border: 1px solid var(--border-color); padding: 0.75rem; border-radius: 8px; margin-bottom: 0.75rem;">
+                <p id="main-original-doc" style="font-size: 0.85rem; margin-top: 0.25rem; line-height: 1.4; color: var(--text-primary); white-space: pre-wrap;">${escapeHtml(rawDocString)}</p>
+            </div>`;
+        docsHtml += '</div>';
+        mockDocsList.innerHTML = docsHtml;
+    }
+
+    // Sync global status bar down to the chat header for better visibility
+    const syncInterval = setInterval(() => {
+        if (statusText && statusBar) {
+            statusText.textContent = statusBar.textContent;
+        }
+    }, 100);
+
+    embedder = await initializeApp(statusBar);
+    
+    clearInterval(syncInterval);
+    
+    if (!embedder) {
+        if (statusDot) statusDot.className = "status-dot";
+        return;
+    }
+    
+    // Precompute docs embeddings
+    const cacheKey = 'docs_rag_embeddings_v2';
+    const cached = localStorage.getItem(cacheKey);
+    
+    if (cached) {
+        docEmbeddings = JSON.parse(cached);
+        statusBar.textContent = "Ready.";
+    } else {
+        statusBar.textContent = "Pre-computing embeddings for mock docs...";
+        if(statusText) statusText.textContent = "Pre-computing embeddings...";
+        
+        try {
+            const docChunkSize = 2;
+            for (let i = 0; i < mockDocs.length; i += docChunkSize) {
+                const chunk = mockDocs.slice(i, i + docChunkSize);
+                const result = await embedder.embed(chunk);
+                result.embeddings.forEach(emb => {
+                    docEmbeddings.push(Array.from(emb.values));
+                });
+            }
+            try {
+                localStorage.setItem(cacheKey, JSON.stringify(docEmbeddings));
+            } catch (e) { console.warn("Could not cache docs embeddings", e); }
+        } catch (e) {
+            console.error("Failed to precompute embeddings:", e);
+            if(statusText) statusText.textContent = "Error pre-computing: " + e.message;
+            if(statusDot) statusDot.className = "status-dot";
+            return;
+        }
+    }
+
+    // Initialize Language Model Session
+    if(statusText) statusText.textContent = "Checking Prompt API availability...";
+    try {
+        if (!window.LanguageModel) throw new Error("Prompt API (LanguageModel) not found in this browser.");
+        
+        const availability = await window.LanguageModel.availability({
+            expectedOutputs: [ { type: "text", languages: ["en"] } ]
+        });
+        
+        if (availability === 'no' || availability === 'unavailable') {
+            throw new Error(`Model availability: ${availability}`);
+        }
+
+        if (availability === 'downloadable' || availability === 'downloading' || availability === 'after-download') {
+            statusText.textContent = 'Model needs downloading. Please click to start.';
+            const btn = document.createElement('button');
+            btn.textContent = 'Start Download';
+            btn.className = "btn";
+            btn.style.marginLeft = '10px';
+            statusText.parentNode.insertBefore(btn, statusText.nextSibling);
+            
+            await new Promise(resolve => {
+                btn.addEventListener('click', () => {
+                    btn.remove();
+                    resolve();
+                });
+            });
+        }
+
+        if(statusText) statusText.textContent = "Checking Prompt API (downloading model)...";
+        languageModelSession = await window.LanguageModel.create({
+            systemPrompt: "You are a strictly grounded assistant. Answer the user's question based ONLY on the provided <context> tags. Do not use external knowledge. Synthesize the information from ALL the provided documents to form your answer.",
+            expectedOutputs: [ { type: "text", languages: ["en"] } ],
+            monitor(m) {
+                m.addEventListener('downloadprogress', (e) => {
+                    const percentage = Math.round((e.loaded / e.total) * 100);
+                    if(statusText) statusText.textContent = `Checking Prompt API (downloading model ${percentage}%)`;
+                });
+            }
+        });
+        
+        if(statusText) statusText.textContent = "Ready! Ask a question.";
+        if(statusDot) statusDot.className = "status-dot ready";
+        statusBar.textContent = "Ready.";
+        statusBar.className = "status-bar ready";
+        
+        docsChatInput.disabled = false;
+        docsChatBtn.disabled = false;
+        
+    } catch (e) {
+        console.error("Language Model Error:", e);
+        if(statusText) statusText.textContent = "Prompt API Error: " + e.message;
+        if(statusDot) statusDot.className = "status-dot";
+    }
+
+    if (docsChatBtn) {
+        docsChatBtn.addEventListener('click', (e) => { e.preventDefault(); performDocsChat(); });
+    }
+    if (docsChatInput) {
+        docsChatInput.addEventListener('keypress', (e) => {
+            if (e.key === 'Enter') { e.preventDefault(); performDocsChat(); }
+        });
+    }
+
+    const suggestionBtns = document.querySelectorAll('.suggestion-btn');
+    suggestionBtns.forEach(btn => {
+        btn.addEventListener('click', () => {
+            if (docsChatInput && !docsChatInput.disabled) {
+                docsChatInput.value = btn.textContent;
+                performDocsChat();
+                // Optionally hide the suggestions after clicking one
+                // btn.parentElement.style.display = 'none';
+            }
+        });
+    });
+}
+
+function appendMessage(sender, text, isBot = false, contextText = '') {
+    const msgDiv = document.createElement('div');
+    msgDiv.className = `message ${isBot ? 'bot' : 'user'}`;
+    
+    let innerHTML;
+    if (isBot && contextText) {
+      innerHTML = `
+        <div class="message-sender">${sender}</div>
+        <div class="message-bubble">
+          <span class="bot-text">${text}</span>
+          <div class="context-used"><strong>Retrieved Context:</strong><br>${contextText.replace(/\n/g, '<br>')}</div>
+        </div>
+      `;
+    } else {
+      innerHTML = `
+        <div class="message-sender">${sender}</div>
+        <div class="message-bubble"><span class="bot-text">${text}</span></div>
+      `;
+    }
+    
+    msgDiv.innerHTML = innerHTML;
+    docsChatResults.appendChild(msgDiv);
+    
+    if (isBot && contextText) {
+      setTimeout(() => {
+        msgDiv.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      }, 50);
+    } else {
+      docsChatResults.scrollTop = docsChatResults.scrollHeight;
+    }
+    
+    return msgDiv;
+}
+
+
+async function performDocsChat() {
+    const question = docsChatInput.value.trim();
+    if (!question || !languageModelSession) return;
+    
+    docsChatInput.value = '';
+    docsChatInput.disabled = true;
+    docsChatBtn.disabled = true;
+
+    appendMessage('You', question, false);
+    
+    try {
+        const result = await embedder.embed([question]);
+        const queryEmbedding = Array.from(result.embeddings[0].values);
+        
+        const searchResults = [];
+        for (let i = 0; i < mockDocs.length; i++) {
+            const sim = cosineSimilarity(queryEmbedding, docEmbeddings[i]);
+            searchResults.push({
+                content: mockDocs[i],
+                score: !isNaN(sim) ? sim : 0,
+                index: i
+            });
+        }
+        searchResults.sort((a, b) => b.score - a.score);
+        
+        // Take top 3 chunks for context
+        const topChunks = searchResults.slice(0, 3);
+        
+        let contextText = topChunks.map((r, i) => `<document id="${i+1}">\n${r.content}\n</document>`).join('\n\n');
+        
+        let displayContextText = topChunks.map((r, i) => {
+          let confClass = 'conf-low';
+          let confText = 'Low Match';
+          if (r.score > 0.8) { confClass = 'conf-high'; confText = 'High Match'; }
+          else if (r.score > 0.6) { confClass = 'conf-medium'; confText = 'Medium Match'; }
+          
+          const badge = `<span class="confidence-badge ${confClass}">${(r.score*100).toFixed(0)}% ${confText}</span>`;
+          return `[${i+1}] ${badge} <span id="rag-doc-${i}" class="rag-doc-text">${r.content}</span>`;
+        }).join('<br><br>');
+
+        const prompt = `<context>\n${contextText}\n</context>\n\n<question>\n${question}\n</question>\n\nBased ONLY on the information provided in the <context> tags above, answer the question. \nCRITICAL INSTRUCTION: After your answer, you MUST provide the exact sentence from the context that you used, formatted exactly like this:\nSOURCE QUOTE: [exact sentence from context]`;
+        
+        const botMsg = appendMessage('Chatbot', 'Thinking...', true, displayContextText);
+        const botTextEl = botMsg.querySelector('.bot-text');
+        
+        const rawResponse = await languageModelSession.prompt(prompt);
+        
+        // Parse the Quote and Highlight
+        let finalAnswer = rawResponse;
+        let quote = "";
+        
+        if (rawResponse.includes("SOURCE QUOTE:")) {
+          const parts = rawResponse.split("SOURCE QUOTE:");
+          finalAnswer = parts[0].trim();
+          quote = parts[1].trim().replace(/^["']|["']$/g, '');
+        }
+        
+        botTextEl.textContent = finalAnswer;
+
+
+        
+
+        
+    } catch (error) {
+        appendMessage('Chatbot', `Error generating response: ${error.message}`, true);
+        console.error(error);
+    } finally {
+        docsChatInput.disabled = false;
+        docsChatBtn.disabled = false;
+        docsChatInput.focus();
+    }
+}
+
+// Start
+init();

--- a/semantic-embedder/index.html
+++ b/semantic-embedder/index.html
@@ -1,0 +1,72 @@
+<!--
+  Copyright 2026 Google LLC
+  SPDX-License-Identifier: Apache-2.0
+-->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>SemanticEmbedder API Prototypes</title>
+    <link rel="stylesheet" href="style.css">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600&family=Outfit:wght@400;600&display=swap" rel="stylesheet">
+    <style>
+        .demo-card {
+            background: var(--surface-color);
+            border: 1px solid var(--border-color);
+            border-radius: 12px;
+            padding: 2rem;
+            margin-bottom: 1.5rem;
+            transition: all 0.2s ease;
+            text-decoration: none;
+            display: block;
+            color: inherit;
+        }
+        .demo-card:hover {
+            border-color: var(--accent-color);
+            transform: translateY(-2px);
+            box-shadow: 0 4px 12px rgba(0,0,0,0.2);
+        }
+        .demo-card h2 {
+            margin-top: 0;
+            color: var(--primary-color);
+        }
+        .demo-card p {
+            color: var(--text-secondary);
+            margin-bottom: 0;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <header>
+            <h1>SemanticEmbedder API Prototypes</h1>
+        </header>
+
+        <main>
+            <p style="text-align: center; margin-bottom: 2rem; color: var(--text-secondary);">
+                <strong>Files to look into:</strong> <code>note_search.js</code>, <code>comment_moderator.js</code>, <code>docs_rag.js</code>
+                <br>
+                <strong>Requirements:</strong> You must enable the <code>chrome://flags/#semantic-embedder-api</code> flag to use these demos.
+            </p>
+
+            <a href="note_search.html" class="demo-card">
+                <h2>1. Semantic Note Search</h2>
+                <p>Search by concept, not just keywords.</p>
+            </a>
+
+            <a href="comment_moderator.html" class="demo-card">
+                <h2>2. Toxic Comment Moderator</h2>
+                <p>Real-time moderation to nudge users away from toxic behavior before they post.</p>
+            </a>
+
+            <a href="docs_rag.html" class="demo-card">
+                <h2>3. Documentation RAG</h2>
+                <p>Chat with documentation using the on-device Semantic Embedder API and Prompt API.</p>
+            </a>
+        </main>
+    </div>
+</body>
+</html>

--- a/semantic-embedder/note_search.html
+++ b/semantic-embedder/note_search.html
@@ -1,0 +1,60 @@
+<!--
+  Copyright 2026 Google LLC
+  SPDX-License-Identifier: Apache-2.0
+-->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Note Search Prototype</title>
+    <link rel="stylesheet" href="style.css">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600&family=Outfit:wght@400;600&display=swap" rel="stylesheet">
+</head>
+<body>
+    <div class="container">
+        <header>
+            <h1>Semantic Note Search</h1>
+            <p>Your data never leaves your device. Search by concept, not just keywords.</p>
+        </header>
+        
+        <div class="status-bar" id="statusBar">
+            Checking API availability...
+        </div>
+
+        <nav class="tabs-nav">
+             <a href="index.html" class="tab-btn">Home</a>
+             <a href="note_search.html" class="tab-btn active">Note Search</a>
+             <a href="comment_moderator.html" class="tab-btn">Comment Moderator</a>
+             <a href="docs_rag.html" class="tab-btn">Docs RAG</a>
+        </nav>
+
+        <main>
+            <div class="tab-content active" style="display: block;">
+                <section class="notes-section">
+                    <div class="notes-layout">
+                        <div class="editor-container">
+                            <h3>My Private Note</h3>
+                            <textarea id="noteEditor" placeholder="Paste sensitive text here (e.g., mock medical records or diary entries)..."></textarea>
+                            <div class="save-status" id="saveStatus">Saved locally</div>
+                        </div>
+                        <div class="search-container">
+                            <h3>Search Notes</h3>
+                            <div class="search-box">
+                                <input type="text" id="noteSearchInput" placeholder="Search for a concept (e.g., 'money issues')">
+                                <button id="noteSearchBtn">Search</button>
+                            </div>
+                            <div id="noteSearchResults" class="results-list">
+                                <p class="placeholder-text">Search results will appear here.</p>
+                            </div>
+                        </div>
+                    </div>
+                </section>
+            </div>
+        </main>
+    </div>
+    <script type="module" src="note_search.js"></script>
+</body>
+</html>

--- a/semantic-embedder/note_search.js
+++ b/semantic-embedder/note_search.js
@@ -1,0 +1,151 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// note_search.js
+import { initializeApp, escapeHtml, debounce } from './shared_ui.js';
+import { cosineSimilarity } from './utils.js';
+
+
+let embedder = null;
+let notes = []; // Array of { text, embedding vector }
+
+// DOM Elements
+const statusBar = document.getElementById('statusBar');
+const noteEditor = document.getElementById('noteEditor');
+const noteSearchInput = document.getElementById('noteSearchInput');
+const noteSearchBtn = document.getElementById('noteSearchBtn');
+const noteSearchResults = document.getElementById('noteSearchResults');
+const saveStatus = document.getElementById('saveStatus');
+
+async function init() {
+    embedder = await initializeApp(statusBar);
+    
+    // Wire up event listeners
+    if (noteEditor) {
+        noteEditor.addEventListener('input', (e) => {
+            updateNoteEmbeddings(e.target.value);
+        });
+    }
+    
+    if (noteSearchBtn) {
+        noteSearchBtn.addEventListener('click', performNoteSearch);
+    }
+    
+    if (noteSearchInput) {
+        noteSearchInput.addEventListener('keypress', (e) => {
+            if (e.key === 'Enter') performNoteSearch();
+        });
+    }
+}
+
+const updateNoteEmbeddings = debounce(async (text) => {
+    if (!embedder) return;
+    
+    saveStatus.textContent = "Generating embeddings...";
+    saveStatus.style.color = "var(--accent-color)";
+    
+    try {
+        const paragraphs = text.split('\n').map(p => p.trim()).filter(p => p.length > 0);
+        
+        if (paragraphs.length === 0) {
+            notes = [];
+            saveStatus.textContent = "Saved (Empty)";
+            saveStatus.style.color = "var(--text-secondary)";
+            return;
+        }
+        
+        const startTime = performance.now();
+        const result = await embedder.embed(paragraphs);
+        const endTime = performance.now();
+        const duration = endTime - startTime;
+        
+        notes = paragraphs.map((p, i) => {
+            return {
+                text: p,
+                embedding: Array.from(result.embeddings[i].values)
+            };
+        });
+        
+        saveStatus.textContent = `Saved locally (${paragraphs.length} paras in ${duration.toFixed(0)}ms, avg ${(duration/paragraphs.length).toFixed(1)}ms/str)`;
+        saveStatus.style.color = "var(--success-color)";
+    } catch (error) {
+        saveStatus.textContent = `Error: ${error.message}`;
+        saveStatus.style.color = "var(--error-color)";
+        console.error(error);
+    }
+}, 1000);
+
+async function performNoteSearch() {
+    const query = noteSearchInput.value.trim();
+    if (!query) return;
+    
+    if (!embedder) {
+        alert("API not initialized.");
+        return;
+    }
+    
+    if (notes.length === 0) {
+        noteSearchResults.innerHTML = '<p class="placeholder-text">No notes to search. Type something in the editor first.</p>';
+        return;
+    }
+    
+    noteSearchResults.innerHTML = '<p class="placeholder-text">Searching...</p>';
+    
+    try {
+        const startTime = performance.now();
+        const result = await embedder.embed([query]);
+        const queryEmbedding = Array.from(result.embeddings[0].values);
+        
+        const endTime = performance.now();
+        const duration = endTime - startTime;
+        
+        const results = [];
+        for (const note of notes) {
+            const sim = cosineSimilarity(queryEmbedding, note.embedding);
+            results.push({
+                text: note.text,
+                score: !isNaN(sim) ? sim : 0
+            });
+        }
+        
+        results.sort((a, b) => b.score - a.score);
+        displayNoteResults(results, duration, queryEmbedding);
+    } catch (error) {
+        noteSearchResults.innerHTML = `<p class="status-bar error">Search failed: ${error.message}</p>`;
+        console.error(error);
+    }
+}
+
+function displayNoteResults(results, duration, queryEmbedding) {
+    const fullEmbeddingStr = JSON.stringify(queryEmbedding);
+    
+    noteSearchResults.innerHTML = `
+        <p class="info-text">Search took ${duration.toFixed(0)}ms</p>
+        <details class="embedding-toggle" style="margin-bottom: 1rem; background: rgba(255,255,255,0.02); border-radius: 6px; border: 1px solid var(--border-color);">
+            <summary style="padding: 0.5rem; cursor: pointer; font-size: 0.9rem; color: var(--accent-color); font-weight: 600;">Show embedding</summary>
+            <div class="embedding-content" style="padding: 0.5rem; border-top: 1px solid var(--border-color);">
+                <pre style="background: rgba(0,0,0,0.2); padding: 0.5rem; border-radius: 4px; overflow: auto; font-size: 0.75rem; color: #a9b7c6; max-height: 150px; white-space: pre-wrap; word-break: break-all;"><code>${fullEmbeddingStr}</code></pre>
+            </div>
+        </details>
+    `;
+    
+    if (results.length === 0) {
+        noteSearchResults.innerHTML += '<p class="placeholder-text">No results found.</p>';
+        return;
+    }
+    
+    results.forEach(res => {
+        const div = document.createElement('div');
+        div.className = 'result-item';
+        div.innerHTML = `
+            <div class="result-score">Score: ${res.score.toFixed(4)}</div>
+            <div class="result-text">${escapeHtml(res.text)}</div>
+        `;
+        noteSearchResults.appendChild(div);
+    });
+}
+
+// Start execution
+init();

--- a/semantic-embedder/shared_ui.js
+++ b/semantic-embedder/shared_ui.js
@@ -1,0 +1,102 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// shared_ui.js
+// NON-CORE LOGIC: Common UI elements, initialization boilerplate, and helpers
+
+/**
+ * Initializes the AI API and handles the download/status UI updates.
+ * @param {HTMLElement} statusBarElement 
+ * @returns {Promise<SemanticEmbedder|null>}
+ */
+export async function initializeApp(statusBarElement) {
+    statusBarElement.textContent = "Checking API availability...";
+    statusBarElement.className = "status-bar";
+    
+    try {
+        const availability = await window.SemanticEmbedder.availability();
+        
+        if (availability === 'unavailable') {
+            throw new Error(`Embedder API is not available.`);
+        }
+        
+        if (availability === 'downloadable') {
+            statusBarElement.textContent = "Click 'Start' to download the AI model";
+            statusBarElement.style.color = "var(--warning-color)";
+            
+            const startBtn = document.createElement('button');
+            startBtn.textContent = "Start Download";
+            Object.assign(startBtn.style, {
+                display: 'block', margin: '10px auto', padding: '10px 20px',
+                background: 'var(--accent-color)', color: 'white',
+                border: 'none', borderRadius: '4px', cursor: 'pointer'
+            });
+            
+            statusBarElement.parentNode.insertBefore(startBtn, statusBarElement.nextSibling);
+            
+            // Wait for user to trigger download
+            await new Promise(resolve => {
+                startBtn.addEventListener('click', () => {
+                    startBtn.remove();
+                    resolve();
+                }, { once: true });
+            });
+            
+            statusBarElement.textContent = "Checking Semantic Embedder API (downloading model)...";
+            window.downloadAnimInterval = setInterval(() => {
+                const dots = Math.floor((Date.now() / 500) % 4);
+                statusBarElement.textContent = "Checking Semantic Embedder API (downloading model)" + ".".repeat(dots);
+            }, 500);
+        } else if (availability === 'downloading') {
+            statusBarElement.textContent = "Model is downloading... Please wait.";
+            statusBarElement.style.color = "var(--warning-color)";
+        } else {
+            statusBarElement.textContent = "Creating Embedder session...";
+        }
+        
+        const embedder = await window.SemanticEmbedder.create();
+        
+        if (window.downloadAnimInterval) {
+            clearInterval(window.downloadAnimInterval);
+            window.downloadAnimInterval = null;
+        }
+        
+        statusBarElement.textContent = "Ready.";
+        statusBarElement.className = "status-bar ready";
+        statusBarElement.style.color = ""; // reset color
+        return embedder;
+        
+    } catch (error) {
+        statusBarElement.textContent = error.message;
+        statusBarElement.className = "status-bar error";
+        statusBarElement.style.color = "var(--error-color)";
+        console.error(error);
+        return null;
+    }
+}
+
+/**
+ * Escapes HTML characters to prevent XSS.
+ */
+export function escapeHtml(text) {
+    const div = document.createElement('div');
+    div.textContent = text;
+    return div.innerHTML;
+}
+
+/**
+ * Debounces a function call.
+ */
+export function debounce(func, wait) {
+    let timeout;
+    return function (...args) {
+        const later = () => {
+            clearTimeout(timeout);
+            func(...args);
+        };
+        clearTimeout(timeout);
+        timeout = setTimeout(later, wait);
+    };
+}

--- a/semantic-embedder/style.css
+++ b/semantic-embedder/style.css
@@ -1,0 +1,678 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+:root {
+    --bg-color: #0b0f19;
+    --card-bg: rgba(23, 32, 53, 0.75);
+    --text-primary: #f8fafc;
+    --text-secondary: #94a3b8;
+    --accent-color: #38bdf8;
+    --accent-gradient: linear-gradient(135deg, #38bdf8 0%, #818cf8 100%);
+    --border-color: rgba(255, 255, 255, 0.08);
+    --success-color: #4ade80;
+    --error-color: #f87171;
+    --nav-bg: rgba(15, 23, 42, 0.5);
+}
+
+body {
+    font-family: 'Inter', sans-serif;
+    background-color: var(--bg-color);
+    color: var(--text-primary);
+    margin: 0;
+    padding: 0;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    min-height: 100vh;
+    background-image: 
+        radial-gradient(circle at 10% 20%, rgba(56, 189, 248, 0.05) 0%, transparent 50%),
+        radial-gradient(circle at 90% 80%, rgba(129, 140, 248, 0.05) 0%, transparent 50%);
+}
+
+.container {
+    width: 95%;
+    max-width: 1400px;
+    margin: 2rem;
+    padding: 2.5rem;
+    background: var(--card-bg);
+    backdrop-filter: blur(16px);
+    border-radius: 28px;
+    border: 1px solid var(--border-color);
+    box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.6);
+}
+
+header {
+    text-align: center;
+    margin-bottom: 2rem;
+}
+
+h1 {
+    font-family: 'Outfit', sans-serif;
+    font-size: 2.8rem;
+    font-weight: 600;
+    margin-bottom: 0.5rem;
+    background: var(--accent-gradient);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+}
+
+header p {
+    color: var(--text-secondary);
+    font-size: 1.1rem;
+}
+
+.status-bar {
+    padding: 0.75rem 1rem;
+    border-radius: 12px;
+    text-align: center;
+    margin-bottom: 2rem;
+    font-size: 0.9rem;
+    background: rgba(255, 255, 255, 0.03);
+    border: 1px solid var(--border-color);
+    transition: all 0.3s ease;
+}
+
+.status-bar.ready {
+    background: rgba(74, 222, 128, 0.05);
+    border-color: rgba(74, 222, 128, 0.15);
+    color: var(--success-color);
+}
+
+.status-bar.error {
+    background: rgba(248, 113, 113, 0.05);
+    border-color: rgba(248, 113, 113, 0.15);
+    color: var(--error-color);
+}
+
+/* Tabs Navigation */
+.tabs-nav {
+    display: flex;
+    gap: 0.5rem;
+    background: var(--nav-bg);
+    padding: 0.5rem;
+    border-radius: 14px;
+    margin-bottom: 2rem;
+    border: 1px solid var(--border-color);
+}
+
+.tab-btn {
+    flex: 1;
+    background: transparent;
+    color: var(--text-secondary);
+    border: none;
+    padding: 0.75rem 1rem;
+    border-radius: 10px;
+    font-weight: 500;
+    font-size: 0.95rem;
+    cursor: pointer;
+    transition: all 0.3s ease;
+}
+
+.tab-btn:hover {
+    color: var(--text-primary);
+    background: rgba(255, 255, 255, 0.03);
+}
+
+.tab-btn.active {
+    background: var(--accent-gradient);
+    color: white;
+    font-weight: 600;
+    box-shadow: 0 4px 12px rgba(56, 189, 248, 0.2);
+}
+
+/* Tab Content */
+.tab-content {
+    display: none;
+    animation: fadeIn 0.4s ease;
+}
+
+.tab-content.active {
+    display: block;
+}
+
+@keyframes fadeIn {
+    from { opacity: 0; transform: translateY(10px); }
+    to { opacity: 1; transform: translateY(0); }
+}
+
+main {
+    display: grid;
+    gap: 2rem;
+}
+
+section {
+    background: rgba(255, 255, 255, 0.01);
+    padding: 2rem;
+    border-radius: 20px;
+    border: 1px solid var(--border-color);
+}
+
+h2 {
+    font-family: 'Outfit', sans-serif;
+    font-size: 1.5rem;
+    margin-top: 0;
+    margin-bottom: 0.5rem;
+    color: var(--text-primary);
+}
+
+.description {
+    color: var(--text-secondary);
+    font-size: 0.95rem;
+    margin-bottom: 1.5rem;
+}
+
+/* Forms & Inputs */
+.input-group {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    margin-bottom: 1.5rem;
+}
+
+label {
+    font-size: 0.9rem;
+    color: var(--text-secondary);
+    font-weight: 500;
+}
+
+input[type="text"], input[type="password"] {
+    background: rgba(255, 255, 255, 0.03);
+    border: 1px solid var(--border-color);
+    border-radius: 12px;
+    padding: 0.85rem 1rem;
+    color: var(--text-primary);
+    font-family: inherit;
+    font-size: 1rem;
+    transition: all 0.3s ease;
+}
+
+input[type="text"]:focus, input[type="password"]:focus {
+    outline: none;
+    border-color: var(--accent-color);
+    background: rgba(255, 255, 255, 0.06);
+    box-shadow: 0 0 0 4px rgba(56, 189, 248, 0.1);
+}
+
+.search-box, .chat-box {
+    display: flex;
+    gap: 0.75rem;
+}
+
+.search-box input, .chat-box input {
+    flex: 1;
+}
+
+button {
+    background: var(--accent-gradient);
+    color: white;
+    border: none;
+    border-radius: 12px;
+    padding: 0.85rem 1.5rem;
+    font-weight: 600;
+    font-size: 1rem;
+    cursor: pointer;
+    transition: all 0.3s ease;
+    box-shadow: 0 4px 12px rgba(56, 189, 248, 0.15);
+}
+
+button:hover:not(:disabled) {
+    transform: translateY(-1px);
+    box-shadow: 0 6px 16px rgba(56, 189, 248, 0.25);
+    opacity: 0.95;
+}
+
+button:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+    box-shadow: none;
+}
+
+/* Results List */
+.results-list {
+    display: grid;
+    gap: 1rem;
+    margin-top: 1rem;
+}
+
+.result-item {
+    background: rgba(255, 255, 255, 0.02);
+    padding: 1.25rem;
+    border-radius: 14px;
+    border: 1px solid var(--border-color);
+    transition: all 0.3s ease;
+}
+
+.result-item:hover {
+    transform: translateX(4px);
+    background: rgba(255, 255, 255, 0.04);
+    border-color: rgba(56, 189, 248, 0.2);
+}
+
+.result-score {
+    font-size: 0.85rem;
+    color: var(--accent-color);
+    font-weight: 600;
+    margin-bottom: 0.5rem;
+}
+
+.result-text {
+    font-size: 0.95rem;
+    color: var(--text-primary);
+    line-height: 1.6;
+}
+
+/* Notes Layout */
+.notes-layout {
+    display: grid;
+    grid-template-columns: 1.5fr 1fr;
+    gap: 1.5rem;
+}
+
+@media (max-width: 768px) {
+    .notes-layout {
+        grid-template-columns: 1fr;
+    }
+}
+
+.editor-container {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+textarea#noteEditor {
+    height: 400px;
+    background: rgba(255, 255, 255, 0.02);
+    border: 1px solid var(--border-color);
+    border-radius: 16px;
+    padding: 1.5rem;
+    color: var(--text-primary);
+    font-family: inherit;
+    font-size: 1rem;
+    line-height: 1.6;
+    resize: none;
+    transition: all 0.3s ease;
+}
+
+textarea#noteEditor:focus {
+    outline: none;
+    border-color: var(--accent-color);
+    background: rgba(255, 255, 255, 0.04);
+    box-shadow: 0 0 0 4px rgba(56, 189, 248, 0.1);
+}
+
+.save-status {
+    font-size: 0.85rem;
+    color: var(--text-secondary);
+    text-align: right;
+}
+
+.search-container {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+/* Moderator Styles */
+.forum-container {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+}
+
+.mock-post {
+    background: rgba(255, 255, 255, 0.02);
+    padding: 1.5rem;
+    border-radius: 14px;
+    border: 1px solid var(--border-color);
+}
+
+.comment-box-container {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+textarea#commentInput {
+    height: 100px;
+    background: rgba(255, 255, 255, 0.03);
+    border: 1px solid var(--border-color);
+    border-radius: 12px;
+    padding: 1rem;
+    color: var(--text-primary);
+    font-family: inherit;
+    font-size: 1rem;
+    resize: none;
+    transition: all 0.3s ease;
+}
+
+textarea#commentInput:focus {
+    outline: none;
+    border-color: var(--accent-color);
+    background: rgba(255, 255, 255, 0.05);
+}
+
+.moderation-warning {
+    background: rgba(245, 158, 11, 0.1);
+    border: 1px solid rgba(245, 158, 11, 0.2);
+    color: #f59e0b;
+    padding: 0.75rem 1rem;
+    border-radius: 8px;
+    font-size: 0.9rem;
+    animation: fadeIn 0.3s ease;
+}
+
+.moderation-stats {
+    margin-top: 0.5rem;
+    font-size: 0.85rem;
+    color: var(--text-secondary);
+    background: rgba(255, 255, 255, 0.05);
+    padding: 0.5rem 0.75rem;
+    border-radius: 6px;
+    display: none;
+}
+
+.moderation-stats.visible {
+    display: block;
+}
+
+.moderation-stats ul {
+    list-style: none;
+    padding: 0;
+    margin: 0.25rem 0 0 0;
+}
+
+.moderation-stats li {
+    display: flex;
+    justify-content: space-between;
+    padding: 0.1rem 0;
+}
+
+.comments-list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.comment-item {
+    background: rgba(255, 255, 255, 0.01);
+    padding: 0.75rem 1rem;
+    border-radius: 8px;
+    border: 1px solid var(--border-color);
+    font-size: 0.95rem;
+}
+
+/* Docs RAG Styles - Polished Chat UI */
+.rag-layout {
+    display: grid;
+    grid-template-columns: 1fr 2fr;
+    gap: 1.5rem;
+}
+
+@media (max-width: 768px) {
+    .rag-layout {
+        grid-template-columns: 1fr;
+    }
+}
+
+.docs-sidebar {
+    background: rgba(255, 255, 255, 0.01);
+    padding: 1.5rem;
+    border-radius: 16px;
+    border: 1px solid var(--border-color);
+}
+
+.docs-sidebar ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+.docs-sidebar li {
+    margin-bottom: 0.5rem;
+}
+
+.mock-docs-list li {
+    font-size: 0.85rem;
+    color: var(--text-secondary);
+    background: rgba(255, 255, 255, 0.02);
+    padding: 0.5rem;
+    border-radius: 6px;
+    margin-bottom: 0.5rem;
+    border-left: 3px solid var(--accent-color);
+    line-height: 1.4;
+}
+
+.chat-container {
+    display: flex;
+    flex-direction: column;
+    min-height: 600px;
+    background: var(--card-bg);
+    border: 1px solid var(--border-color);
+    border-radius: 1rem;
+    overflow: hidden;
+    box-shadow: 0 10px 25px rgba(0, 0, 0, 0.2);
+}
+
+.chat-header {
+    padding: 1.25rem;
+    border-bottom: 1px solid var(--border-color);
+    background: rgba(0, 0, 0, 0.2);
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.chat-header h2 {
+    font-size: 1.2rem;
+    font-weight: 600;
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    margin: 0;
+}
+
+.status-indicator {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-size: 0.85rem;
+    color: var(--text-secondary);
+}
+
+.status-dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: var(--error-color);
+    box-shadow: 0 0 8px var(--error-color);
+}
+
+.status-dot.ready {
+    background: var(--success-color);
+    box-shadow: 0 0 8px var(--success-color);
+}
+
+.chat-messages {
+    flex: 1;
+    padding: 1.5rem;
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+    max-height: 500px;
+}
+
+.message {
+    display: flex;
+    flex-direction: column;
+    max-width: 80%;
+    animation: slideUp 0.3s ease-out;
+}
+
+@keyframes slideUp {
+    from { opacity: 0; transform: translateY(10px); }
+    to { opacity: 1; transform: translateY(0); }
+}
+
+.message.user {
+    align-self: flex-end;
+}
+
+.message.bot {
+    align-self: flex-start;
+}
+
+.message.system {
+    align-self: center;
+    max-width: 95%;
+}
+
+.message-sender {
+    font-size: 0.8rem;
+    color: var(--text-secondary);
+    margin-bottom: 0.25rem;
+    padding: 0 0.5rem;
+}
+
+.message-bubble {
+    padding: 1rem 1.25rem;
+    border-radius: 1rem;
+    font-size: 0.95rem;
+    line-height: 1.5;
+}
+
+.message.user .message-bubble {
+    background: var(--accent-color);
+    color: var(--bg-color);
+    border-bottom-right-radius: 0.25rem;
+    font-weight: 500;
+}
+
+.message.bot .message-bubble {
+    background: rgba(255, 255, 255, 0.05);
+    border: 1px solid var(--border-color);
+    border-bottom-left-radius: 0.25rem;
+}
+
+.message.system .message-bubble {
+    background: rgba(255, 255, 255, 0.02);
+    border: 1px dashed rgba(255, 255, 255, 0.15);
+    color: var(--text-secondary);
+    font-size: 0.8rem;
+    padding: 0.5rem 0.75rem;
+}
+
+.message.bot .context-used {
+    margin-top: 0.75rem;
+    padding-top: 0.75rem;
+    border-top: 1px solid rgba(255, 255, 255, 0.1);
+    font-size: 0.8rem;
+    color: var(--text-secondary);
+}
+
+.chat-input-area {
+    padding: 1.25rem;
+    border-top: 1px solid var(--border-color);
+    background: rgba(0, 0, 0, 0.2);
+}
+
+.input-wrapper {
+    display: flex;
+    gap: 0.75rem;
+    background: rgba(0, 0, 0, 0.2);
+    border: 1px solid var(--border-color);
+    border-radius: 2rem;
+    padding: 0.5rem;
+    transition: all 0.3s ease;
+}
+
+.input-wrapper:focus-within {
+    border-color: var(--accent-color);
+    box-shadow: 0 0 0 2px rgba(56, 189, 248, 0.2);
+    background: rgba(0, 0, 0, 0.4);
+}
+
+.chat-input {
+    flex: 1;
+    background: transparent;
+    border: none;
+    color: var(--text-primary);
+    font-family: inherit;
+    font-size: 0.95rem;
+    padding: 0.5rem 1rem;
+    outline: none;
+}
+
+.chat-input::placeholder {
+    color: var(--text-secondary);
+}
+
+.send-btn {
+    background: var(--accent-color);
+    color: var(--bg-color);
+    border: none;
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+
+.send-btn:hover {
+    transform: scale(1.05);
+}
+
+.send-btn:disabled {
+    background: var(--border-color);
+    cursor: not-allowed;
+    transform: none;
+}
+
+/* Confidence Badges */
+.confidence-badge {
+  display: inline-block;
+  padding: 0.1rem 0.4rem;
+  border-radius: 4px;
+  font-size: 0.7rem;
+  font-weight: bold;
+  margin-right: 0.5rem;
+  vertical-align: middle;
+}
+.conf-high { background: rgba(16, 185, 129, 0.2); color: #6ee7b7; border: 1px solid rgba(16, 185, 129, 0.4); }
+.conf-medium { background: rgba(245, 158, 11, 0.2); color: #fcd34d; border: 1px solid rgba(245, 158, 11, 0.4); }
+.conf-low { background: rgba(107, 114, 128, 0.2); color: #9ca3af; border: 1px solid rgba(107, 114, 128, 0.4); }
+
+/* Suggested Questions */
+.suggested-questions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin-top: 0.75rem;
+    padding: 0 0.5rem;
+}
+
+button.suggestion-btn {
+    background: rgba(255, 255, 255, 0.05);
+    border: 1px solid var(--border-color);
+    color: var(--text-secondary);
+    padding: 0.4rem 0.8rem;
+    font-size: 0.8rem;
+    font-weight: 400;
+    border-radius: 20px;
+    box-shadow: none;
+    text-align: left;
+}
+
+button.suggestion-btn:hover {
+    background: rgba(255, 255, 255, 0.1);
+    border-color: var(--accent-color);
+    color: var(--text-primary);
+    transform: translateY(-1px);
+    box-shadow: 0 2px 8px rgba(0,0,0,0.2);
+}

--- a/semantic-embedder/utils.js
+++ b/semantic-embedder/utils.js
@@ -1,0 +1,21 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// utils.js
+// Utility functions for embedding apps
+
+/**
+ * Helper to compute cosine similarity between two vectors.
+ * Useful for finding nearest neighbors after computing embeddings.
+ */
+export function cosineSimilarity(vecA, vecB) {
+    let dotProduct = 0.0, normA = 0.0, normB = 0.0;
+    for (let i = 0; i < vecA.length; i++) {
+        dotProduct += vecA[i] * vecB[i];
+        normA += vecA[i] * vecA[i];
+        normB += vecB[i] * vecB[i];
+    }
+    return dotProduct / (Math.sqrt(normA) * Math.sqrt(normB));
+}

--- a/wordup/e2e/adversarial.test.ts
+++ b/wordup/e2e/adversarial.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import {
   setupE2ETest as originalSetupE2ETest,

--- a/wordup/e2e/challenger.test.ts
+++ b/wordup/e2e/challenger.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { describe, it, expect, beforeEach } from 'vitest';
 import {
   setupE2ETest,

--- a/wordup/e2e/reactivity_stress.test.ts
+++ b/wordup/e2e/reactivity_stress.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { describe, it, expect, beforeEach } from 'vitest';
 import {
   setupE2ETest,

--- a/wordup/e2e/runner.ts
+++ b/wordup/e2e/runner.ts
@@ -1,3 +1,8 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { mount, unmount, tick } from 'svelte';
 import App from '../src/App.svelte';
 import { IDBFactory } from 'fake-indexeddb';

--- a/wordup/e2e/sanity.test.ts
+++ b/wordup/e2e/sanity.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { describe, it, expect, beforeEach } from 'vitest';
 import {
   setupE2ETest,

--- a/wordup/e2e/tier1_features.test.ts
+++ b/wordup/e2e/tier1_features.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { tick } from 'svelte';
 import {

--- a/wordup/e2e/tier2_boundaries.test.ts
+++ b/wordup/e2e/tier2_boundaries.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import {
   setupE2ETest as originalSetupE2ETest,

--- a/wordup/e2e/tier3_combinations.test.ts
+++ b/wordup/e2e/tier3_combinations.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { describe, it, expect, beforeEach } from 'vitest';
 import {
   setupE2ETest,

--- a/wordup/e2e/tier4_scenarios.test.ts
+++ b/wordup/e2e/tier4_scenarios.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { describe, it, expect, beforeEach } from 'vitest';
 import {
   setupE2ETest as originalSetupE2ETest,

--- a/wordup/e2e/tier5_adversarial.test.ts
+++ b/wordup/e2e/tier5_adversarial.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { tick } from 'svelte';
 import {

--- a/wordup/index.html
+++ b/wordup/index.html
@@ -1,3 +1,7 @@
+<!--
+  Copyright 2026 Google LLC
+  SPDX-License-Identifier: Apache-2.0
+-->
 <!doctype html>
 <html lang="en">
   <head>

--- a/wordup/src/app.css
+++ b/wordup/src/app.css
@@ -1,3 +1,8 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 html, body {
   margin: 0;
   padding: 0;

--- a/wordup/src/lib/db.ts
+++ b/wordup/src/lib/db.ts
@@ -1,3 +1,8 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 export interface LetterCell {
   letter: string;
   status: 'correct' | 'present' | 'absent';

--- a/wordup/src/lib/gameStore.svelte.ts
+++ b/wordup/src/lib/gameStore.svelte.ts
@@ -1,3 +1,8 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import {
   loadStats,
   loadSession,

--- a/wordup/src/lib/gameStoreDb.ts
+++ b/wordup/src/lib/gameStoreDb.ts
@@ -1,3 +1,8 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import {
   saveStats,
   saveSession,

--- a/wordup/src/lib/gameStoreHelpers.ts
+++ b/wordup/src/lib/gameStoreHelpers.ts
@@ -1,3 +1,8 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import type { LetterCell, SavedSession } from './db';
 
 export interface ResolvedSession {

--- a/wordup/src/lib/gameStoreTypes.ts
+++ b/wordup/src/lib/gameStoreTypes.ts
@@ -1,3 +1,8 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import type { LetterCell } from './db';
 
 export interface GameState {

--- a/wordup/src/lib/promptClient.ts
+++ b/wordup/src/lib/promptClient.ts
@@ -1,3 +1,8 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import type { LetterCell } from './db';
 
 const sessionOptions = {

--- a/wordup/src/lib/webmcp.ts
+++ b/wordup/src/lib/webmcp.ts
@@ -1,3 +1,8 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import type { GameStore } from './gameStoreTypes';
 
 export interface WebMCPRegisterToolOptions {

--- a/wordup/src/main.ts
+++ b/wordup/src/main.ts
@@ -1,3 +1,8 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { mount } from 'svelte'
 import './app.css'
 import App from './App.svelte'

--- a/wordup/svelte.config.js
+++ b/wordup/svelte.config.js
@@ -1,2 +1,7 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 /** @type {import("@sveltejs/vite-plugin-svelte").SvelteConfig} */
 export default {}

--- a/wordup/vite.config.ts
+++ b/wordup/vite.config.ts
@@ -1,3 +1,8 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { defineConfig } from 'vite'
 import { svelte } from '@sveltejs/vite-plugin-svelte'
 import { VitePWA } from 'vite-plugin-pwa'

--- a/wordup/vitest.config.ts
+++ b/wordup/vitest.config.ts
@@ -1,3 +1,8 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { defineConfig } from 'vitest/config';
 import { svelte } from '@sveltejs/vite-plugin-svelte';
 


### PR DESCRIPTION
Adds a new `semantic-embedder/` directory with three demos built on the Semantic Embedder API:

- **Comment moderator** (`comment_moderator.html`) — classifies comments by embedding similarity.
- **Docs RAG** (`docs_rag.html`) — retrieval-augmented answering over a small doc set.
- **Note search** (`note_search.html`) — semantic search across notes.

Plus shared UI/util modules, styles, and demo assets.

### Commits

1. **Add semantic embedder demos** — the actual data/content of this PR.
2. **Add missing license headers** — no functional change; just adds the missing license headers to existing `wordup/` and `prompt-api-polyfill/` files.

/cc @andreban