### PR TITLE
Clear the results when the search field is emptied

### DIFF
--- a/semantic-docs-search/script.js
+++ b/semantic-docs-search/script.js
@@ -567,6 +567,21 @@ const build = async () => {
   await describeIndex();
 };
 
+// Emptying the field takes the results with it: they answer a question that is
+// no longer being asked, along with the passages they had marked for
+// highlighting.
+const clearResults = () => {
+  results.replaceChildren();
+  results.hidden = true;
+  needles.clear();
+  for (const marked of content.querySelectorAll(".match")) {
+    marked.classList.remove("match");
+  }
+  if (semanticIndex.length) {
+    indexStatus.textContent = summarizeIndex();
+  }
+};
+
 const runSearch = async (event) => {
   event.preventDefault();
   const query = queryInput.value.trim();
@@ -617,6 +632,11 @@ const start = async () => {
 
 filter.addEventListener("input", applyFilter);
 searchForm.addEventListener("submit", runSearch);
+queryInput.addEventListener("input", () => {
+  if (!queryInput.value.trim()) {
+    clearResults();
+  }
+});
 buildButton.addEventListener("click", build);
 
 window.addEventListener("hashchange", () => {


### PR DESCRIPTION
Emptying the "Search by meaning" field now clears the result list, instead of leaving results up for a question that is no longer being asked. The passages those results had marked for highlighting are unmarked with them, and the status line goes back to describing the index.

Covers the native `input` event, so the field's own ✕ clears the results too.

The same change is on the two stacked demo branches: [#440](https://github.com/GoogleChromeLabs/web-ai-demos/pull/440) for the vector store demo, and the prompt-grounding demo that sits on top of it.

Verified against a freshly built index in Chrome Canary: ten results and two highlighted blocks before clearing, none after.