### PR TITLE
Add Prompt API tool use demo

### DIFF
--- a/prompt-api-tool-use/index.html
+++ b/prompt-api-tool-use/index.html
@@ -23,7 +23,9 @@
     <div id="controls">
       <div id="status">Initializing…</div>
       <button id="activate-btn" type="button" hidden>Download the model</button>
-      <button id="reset-btn" type="button" disabled>Reset session</button>
+      <button id="reset-btn" type="button" aria-disabled="true">
+        Reset session
+      </button>
     </div>
     <progress id="dl-progress"></progress>
 
@@ -47,13 +49,17 @@
         type="text"
         autocomplete="off"
         placeholder="Ask about npm packages or GitHub repositories…"
-        disabled
+        readonly
+        aria-disabled="true"
       />
-      <button id="send-btn" type="submit" disabled>Send</button>
+      <button id="send-btn" type="submit" aria-disabled="true">Send</button>
     </form>
 
     <details id="debug">
       <summary>Debug: messages exchanged with the model</summary>
+      <div id="debug-toolbar">
+        <button id="copy-debug" type="button">Copy as JSON</button>
+      </div>
       <div id="debug-log"></div>
     </details>
 

--- a/prompt-api-tool-use/index.html
+++ b/prompt-api-tool-use/index.html
@@ -20,6 +20,11 @@
       call is logged below as it happens.
     </p>
 
+    <p class="requirement" id="flag-note" hidden>
+      This demo requires the flag
+      <code>chrome://flags/#prompt-api-tool-use</code> to be enabled.
+    </p>
+
     <div id="controls">
       <div id="status" role="status">Initializing…</div>
       <button id="activate-btn" type="button" hidden>Download the model</button>

--- a/prompt-api-tool-use/index.html
+++ b/prompt-api-tool-use/index.html
@@ -1,0 +1,62 @@
+<!--
+  SPDX-License-Identifier: Apache-2.0
+  Copyright 2026 Google LLC
+-->
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Tool Use — Prompt API</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <h1>Tool Use — Prompt API</h1>
+    <p class="subtitle">
+      The model is given two tools: one that searches npm for packages that have
+      an associated GitHub repository, and one that looks up a repository's star
+      count. Ask a question that needs both and the model decides which tools to
+      call, in which order, and how to feed one result into the next. Every tool
+      call is logged below as it happens.
+    </p>
+
+    <div id="controls">
+      <div id="status">Initializing…</div>
+      <button id="activate-btn" type="button" hidden>Download the model</button>
+      <button id="reset-btn" type="button" disabled>Reset session</button>
+    </div>
+    <progress id="dl-progress"></progress>
+
+    <div id="examples">
+      <button class="example" type="button">
+        Which npm package for CSV parsing is the most popular on GitHub?
+      </button>
+      <button class="example" type="button">
+        Find me three npm packages for date formatting and rank them by stars.
+      </button>
+      <button class="example" type="button">
+        How many stars does GoogleChromeLabs/browser-fs-access have?
+      </button>
+    </div>
+
+    <div id="chat"></div>
+
+    <form id="composer">
+      <input
+        id="user-input"
+        type="text"
+        autocomplete="off"
+        placeholder="Ask about npm packages or GitHub repositories…"
+        disabled
+      />
+      <button id="send-btn" type="submit" disabled>Send</button>
+    </form>
+
+    <details id="debug">
+      <summary>Debug: messages exchanged with the model</summary>
+      <div id="debug-log"></div>
+    </details>
+
+    <script type="module" src="script.js"></script>
+  </body>
+</html>

--- a/prompt-api-tool-use/index.html
+++ b/prompt-api-tool-use/index.html
@@ -21,7 +21,7 @@
     </p>
 
     <div id="controls">
-      <div id="status">Initializing…</div>
+      <div id="status" role="status">Initializing…</div>
       <button id="activate-btn" type="button" hidden>Download the model</button>
       <button id="reset-btn" type="button" aria-disabled="true">
         Reset session

--- a/prompt-api-tool-use/script.js
+++ b/prompt-api-tool-use/script.js
@@ -14,6 +14,7 @@ const sendBtn = document.getElementById('send-btn');
 const resetBtn = document.getElementById('reset-btn');
 const activateBtn = document.getElementById('activate-btn');
 const debugLog = document.getElementById('debug-log');
+const copyDebugBtn = document.getElementById('copy-debug');
 
 const SYSTEM_PROMPT = `You are a helpful assistant that answers questions about
 npm packages and GitHub repositories. You have tools available. Use them instead
@@ -23,6 +24,11 @@ exist, and those numbers change constantly.
 To find out how popular a package is, first search npm for it, then look up the
 star count of the GitHub repository the search returns. Call get_repo_stars once
 per repository you want to compare.
+
+If a package is marked "sharedRepository": true, its stars belong to a
+repository that holds several packages. Say that the count is for the whole
+repository rather than for that package, and do not rank it against standalone
+packages as though the numbers meant the same thing.
 
 Answer in one short paragraph. Always give the exact star counts the tools gave
 you, and never invent one.`;
@@ -114,11 +120,27 @@ function appendToolCall(name, args) {
   };
 }
 
+// `disabled` takes a control out of the focus order and hides it from
+// assistive technology, so a keyboard user tabbing through the page loses it
+// while a turn runs. `aria-disabled` keeps it focusable and announces it as
+// unavailable instead, which means the control still gets clicked: every
+// handler below rejects the activation itself.
+function setDisabled(element, value) {
+  element.setAttribute('aria-disabled', String(value));
+}
+
+function isDisabled(element) {
+  return element.getAttribute('aria-disabled') === 'true';
+}
+
 function setBusy(value) {
   busy = value;
-  userInput.disabled = value;
-  sendBtn.disabled = value;
-  resetBtn.disabled = value;
+  // `readonly` rather than `disabled`: it blocks typing while keeping the
+  // field focusable and readable.
+  userInput.readOnly = value;
+  setDisabled(userInput, value);
+  setDisabled(sendBtn, value);
+  setDisabled(resetBtn, value);
   if (!value) {
     userInput.focus();
   }
@@ -248,9 +270,16 @@ function asMessages(role, payload) {
   return [{ role, content: asContent(payload) }];
 }
 
+// Every message logged below, in order: the transcript the copy button hands
+// over, and what you would store to replay the session.
+const transcript = [];
+
 // Records one leg of the exchange: `↑` for what the page sends into the
 // session, `↓` for what the model sends back.
 function logExchange(direction, label, role, payload) {
+  const messages = plainify(asMessages(role, payload));
+  transcript.push(...messages);
+
   const entry = document.createElement('div');
   entry.className = `exchange ${direction}`;
 
@@ -260,7 +289,7 @@ function logExchange(direction, label, role, payload) {
   entry.append(heading);
 
   const pre = document.createElement('pre');
-  pre.textContent = JSON.stringify(plainify(asMessages(role, payload)), null, 2);
+  pre.textContent = JSON.stringify(messages, null, 2);
   entry.append(pre);
 
   debugLog.append(entry);
@@ -272,6 +301,25 @@ function logSystemPrompt() {
   logExchange('sent', 'initialPrompts', 'system', SYSTEM_PROMPT);
 }
 
+// Records a failed round in the debug view. Deliberately not added to
+// `transcript`: the copied JSON stays a valid list of messages, while the
+// rendered log still explains why the exchange stopped where it did.
+function logError(message) {
+  const entry = document.createElement('div');
+  entry.className = 'exchange failed';
+
+  const heading = document.createElement('div');
+  heading.className = 'exchange-label';
+  heading.textContent = '⚠ error';
+  entry.append(heading);
+
+  const pre = document.createElement('pre');
+  pre.textContent = message;
+  entry.append(pre);
+
+  debugLog.append(entry);
+}
+
 function logTurnStart(question) {
   const heading = document.createElement('div');
   heading.className = 'exchange-turn';
@@ -281,6 +329,20 @@ function logTurnStart(question) {
 
 // ─── Tool-call loop ──────────────────────────────────────────────────────────
 
+// Reports which of a tool's required arguments the model left out. Small
+// models regularly call a tool with `arguments: {}`, and running the tool
+// anyway sends undefined values to the API: a wasted request, answered with a
+// misleading error. `get_repo_stars` with no arguments asks GitHub about
+// `/repos/undefined/undefined` and reports "not found", which reads as "that
+// repository does not exist" rather than "you forgot the arguments".
+function missingArguments(tool, args) {
+  const required = tool.inputSchema?.required ?? [];
+  return required.filter((key) => {
+    const value = args?.[key];
+    return value === undefined || value === null || value === '';
+  });
+}
+
 // Runs one tool the model asked for. Returns either the tool's parsed output
 // or a failure message, so the caller can build a tool success or a tool error.
 async function runTool(name, args) {
@@ -289,6 +351,17 @@ async function runTool(name, args) {
     // The model hallucinated a tool. Report it as a tool error rather than
     // throwing, so it can correct itself on the next turn.
     return { ok: false, message: `There is no tool named ${name}.` };
+  }
+
+  const missing = missingArguments(tool, args);
+  if (missing.length) {
+    // Name what is missing, so the next attempt can fix it.
+    const list = missing.map((key) => `"${key}"`).join(' and ');
+    const message =
+      `${name} was called without ${list}. Call it again and provide ` +
+      `${missing.length > 1 ? 'those arguments' : 'that argument'}.`;
+    appendToolCall(name, args ?? {}).fail(message);
+    return { ok: false, message };
   }
 
   const entry = appendToolCall(name, args ?? {});
@@ -304,6 +377,28 @@ async function runTool(name, args) {
   }
 }
 
+// Chrome refuses a tool result that contains a JSON null anywhere inside it:
+// null converts to base::Value::Type::NONE, ContainsNoneType() sees it, and
+// ConvertToolSuccessToDictValue() fails, which surfaces as "Failed to
+// serialize tool result. Value may contain circular references...". The whole
+// turn dies on it. GitHub returns `description: null` for a repository without
+// a description, so strip nulls instead of handing one over.
+function withoutNulls(value) {
+  if (Array.isArray(value)) {
+    return value
+      .filter((item) => item !== null && item !== undefined)
+      .map(withoutNulls);
+  }
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value)
+        .filter(([, item]) => item !== null && item !== undefined)
+        .map(([key, item]) => [key, withoutNulls(item)]),
+    );
+  }
+  return value;
+}
+
 // Builds one `tool-response` content part for a call the model made.
 //
 // The value has to be a real LanguageModelToolSuccess or LanguageModelToolError
@@ -315,9 +410,10 @@ function toolResponsePart(call, outcome) {
     ? new LanguageModelToolSuccess({
         callID: call.callID,
         name: call.name,
-        // `object` takes any JSON-serializable value. Chrome currently
-        // supports only `text` and `object` here, not `image` or `audio`.
-        result: [{ type: 'object', value: outcome.value }],
+        // `object` takes any JSON-serializable value, minus nulls. Chrome
+        // currently supports only `text` and `object` here, not `image` or
+        // `audio`.
+        result: [{ type: 'object', value: withoutNulls(outcome.value) ?? {} }],
       })
     : new LanguageModelToolError({
         callID: call.callID,
@@ -446,6 +542,7 @@ async function ask(question) {
 
   } catch (error) {
     appendMessage('error', `Something went wrong: ${error.message}`);
+    logError(`${error.name}: ${error.message}`);
   } finally {
     // In `finally`, so the status is correct however the turn ended: a normal
     // answer, a sanitizer stop, the tool-call cap, or a thrown error.
@@ -462,7 +559,7 @@ async function ask(question) {
 // straight from a click when the model still has to be downloaded, because
 // create() then needs transient user activation.
 async function createSession() {
-  activateBtn.disabled = true;
+  setDisabled(activateBtn, true);
   setStatus('Preparing the model…');
 
   try {
@@ -487,7 +584,7 @@ async function createSession() {
     logSystemPrompt();
   } catch (error) {
     dlProgress.style.display = 'none';
-    activateBtn.disabled = false;
+    setDisabled(activateBtn, false);
     setStatus(`Could not create a session: ${error.message}`);
     return;
   }
@@ -529,7 +626,7 @@ async function initSession() {
       ? 'Finish downloading the model'
       : 'Download the model';
   activateBtn.hidden = false;
-  activateBtn.disabled = false;
+  setDisabled(activateBtn, false);
   setStatus(
     'The model has to be downloaded before this demo can run. Click the ' +
       'button to start; the download is a few gigabytes and only happens once.',
@@ -550,6 +647,7 @@ async function resetSession() {
 
   chatEl.replaceChildren();
   debugLog.replaceChildren();
+  transcript.length = 0;
   logSystemPrompt();
   turn = 0;
   setBusy(false);
@@ -560,6 +658,11 @@ async function resetSession() {
 
 formEl.addEventListener('submit', (event) => {
   event.preventDefault();
+  // Submitting is still possible while aria-disabled, by clicking Send or by
+  // pressing Enter in the field, so refuse it here.
+  if (isDisabled(sendBtn)) {
+    return;
+  }
   const question = userInput.value.trim();
   if (!question) {
     return;
@@ -568,7 +671,20 @@ formEl.addEventListener('submit', (event) => {
   ask(question);
 });
 
+copyDebugBtn.addEventListener('click', async () => {
+  // One JSON array of every message, in order.
+  await navigator.clipboard.writeText(JSON.stringify(transcript, null, 2));
+  const label = copyDebugBtn.textContent;
+  copyDebugBtn.textContent = `Copied ${transcript.length} messages`;
+  setTimeout(() => {
+    copyDebugBtn.textContent = label;
+  }, 2000);
+});
+
 activateBtn.addEventListener('click', () => {
+  if (isDisabled(activateBtn)) {
+    return;
+  }
   // The click is what grants the transient activation create() needs.
   if (!navigator.userActivation?.isActive) {
     setStatus('Interact with the page first, then try again.');
@@ -577,10 +693,20 @@ activateBtn.addEventListener('click', () => {
   createSession();
 });
 
-resetBtn.addEventListener('click', resetSession);
+resetBtn.addEventListener('click', () => {
+  if (isDisabled(resetBtn)) {
+    return;
+  }
+  resetSession();
+});
 
 for (const button of document.querySelectorAll('.example')) {
   button.addEventListener('click', () => {
+    // The example buttons are never marked unavailable, but they start a turn
+    // just like Send does, so they get the same guard.
+    if (busy || !session) {
+      return;
+    }
     ask(button.textContent.trim());
   });
 }

--- a/prompt-api-tool-use/script.js
+++ b/prompt-api-tool-use/script.js
@@ -21,9 +21,16 @@ npm packages and GitHub repositories. You have tools available. Use them instead
 of guessing: you have no reliable knowledge of star counts or of which packages
 exist, and those numbers change constantly.
 
-To find out how popular a package is, first search npm for it, then look up the
-star count of the GitHub repository the search returns. Call get_repo_stars once
-per repository you want to compare.
+When someone asks which package is the most popular, work through these steps
+in order:
+
+1. Call search_npm_packages once.
+2. Call get_repo_stars for every single package that search returned, one call
+   at a time, until none are left.
+3. Only once you hold a star count for every package, name the winner.
+
+Never compare star counts before you have looked all of them up, and never
+call a package the most popular when you only checked one of them.
 
 If a package is marked "sharedRepository": true, its stars belong to a
 repository that holds several packages. Say that the count is for the whole
@@ -42,6 +49,13 @@ const declarations = tools.map(({ name, description, inputSchema }) => ({
   inputSchema,
 }));
 const toolsByName = new Map(tools.map((tool) => [tool.name, tool]));
+
+// Each tool gets its own color, so a long chain of calls can be read at a
+// glance. Slots are assigned by declaration order and cycle once they run out.
+const TOOL_COLOR_COUNT = 6;
+const toolColors = new Map(
+  tools.map((tool, index) => [tool.name, index % TOOL_COLOR_COUNT]),
+);
 
 // Shared by availability() and create(), so the availability check asks about
 // the same session this demo actually wants: one that can emit tool calls and
@@ -95,6 +109,11 @@ function appendToolCall(name, args) {
   const details = document.createElement('details');
   details.className = 'tool-call';
   details.open = true;
+  // A tool the model invented has no slot, and keeps the neutral styling.
+  const color = toolColors.get(name);
+  if (color !== undefined) {
+    details.dataset.tool = String(color);
+  }
 
   const summary = document.createElement('summary');
   const label = `${name}(${JSON.stringify(args)})`;
@@ -114,6 +133,8 @@ function appendToolCall(name, args) {
       pre.textContent = JSON.stringify(result, null, 2);
     },
     fail(message) {
+      // A failed call reads as failed, rather than as its tool's color.
+      details.classList.add('failed');
       summary.textContent = `⚠ ${label} failed`;
       pre.textContent = message;
     },
@@ -350,7 +371,9 @@ async function runTool(name, args) {
   if (!tool) {
     // The model hallucinated a tool. Report it as a tool error rather than
     // throwing, so it can correct itself on the next turn.
-    return { ok: false, message: `There is no tool named ${name}.` };
+    const message = `There is no tool named ${name}.`;
+    appendToolCall(name, args ?? {}).fail(message);
+    return { ok: false, message };
   }
 
   const missing = missingArguments(tool, args);

--- a/prompt-api-tool-use/script.js
+++ b/prompt-api-tool-use/script.js
@@ -1,0 +1,588 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Google LLC
+
+import * as smd from 'https://cdn.jsdelivr.net/npm/streaming-markdown@0.0.17/smd.min.js';
+
+import { tools } from './tools.js';
+
+const statusEl = document.getElementById('status');
+const dlProgress = document.getElementById('dl-progress');
+const chatEl = document.getElementById('chat');
+const formEl = document.getElementById('composer');
+const userInput = document.getElementById('user-input');
+const sendBtn = document.getElementById('send-btn');
+const resetBtn = document.getElementById('reset-btn');
+const activateBtn = document.getElementById('activate-btn');
+const debugLog = document.getElementById('debug-log');
+
+const SYSTEM_PROMPT = `You are a helpful assistant that answers questions about
+npm packages and GitHub repositories. You have tools available. Use them instead
+of guessing: you have no reliable knowledge of star counts or of which packages
+exist, and those numbers change constantly.
+
+To find out how popular a package is, first search npm for it, then look up the
+star count of the GitHub repository the search returns. Call get_repo_stars once
+per repository you want to compare.
+
+Answer in one short paragraph. Always give the exact star counts the tools gave
+you, and never invent one.`;
+
+// The model is only told what a tool is called, what it does, and what it takes.
+// `execute()` stays on this side: the browser never runs it, the tool-call loop
+// below does.
+const declarations = tools.map(({ name, description, inputSchema }) => ({
+  name,
+  description,
+  inputSchema,
+}));
+const toolsByName = new Map(tools.map((tool) => [tool.name, tool]));
+
+// Shared by availability() and create(), so the availability check asks about
+// the same session this demo actually wants: one that can emit tool calls and
+// accept tool responses. Declaring the output language keeps Chrome from
+// warning that none was specified.
+const SESSION_OPTIONS = {
+  expectedInputs: [
+    { type: 'text', languages: ['en'] },    
+    { type: 'tool-response' },
+    // If you want to replay a session later, tool calls become inputs.
+    { type: 'tool-call' },
+  ],
+  expectedOutputs: [
+    { type: 'text', languages: ['en'] },
+    { type: 'tool-call' },
+  ],
+  tools: declarations,
+};
+
+// A misbehaving model could keep asking for tools forever, so cap the round
+// trips per question.
+const MAX_TOOL_CALLS = 8;
+
+// `baseSession` is created once and never prompted, so it stays at the system
+// prompt. Every conversation is a clone of it, which is far cheaper than
+// building a session from scratch: no model load, no re-processing of the
+// system prompt or the tool declarations.
+let baseSession = null;
+let session = null;
+let busy = false;
+let turn = 0;
+
+// ─── UI helpers ──────────────────────────────────────────────────────────────
+
+function setStatus(text) {
+  statusEl.textContent = text;
+}
+
+function appendMessage(role, text) {
+  const el = document.createElement('div');
+  el.className = `message ${role}`;
+  el.textContent = text;
+  chatEl.append(el);
+  el.scrollIntoView({ block: 'nearest' });
+  return el;
+}
+
+// Renders one tool call as a collapsible entry in the chat, so the sequence of
+// calls stays interleaved with the conversation that caused it.
+function appendToolCall(name, args) {
+  const details = document.createElement('details');
+  details.className = 'tool-call';
+  details.open = true;
+
+  const summary = document.createElement('summary');
+  const label = `${name}(${JSON.stringify(args)})`;
+  summary.textContent = `⚙ ${label} …`;
+  details.append(summary);
+
+  const pre = document.createElement('pre');
+  pre.textContent = 'Running…';
+  details.append(pre);
+
+  chatEl.append(details);
+  details.scrollIntoView({ block: 'nearest' });
+
+  return {
+    finish(result, ms) {
+      summary.textContent = `⚙ ${label} — ${ms} ms`;
+      pre.textContent = JSON.stringify(result, null, 2);
+    },
+    fail(message) {
+      summary.textContent = `⚠ ${label} failed`;
+      pre.textContent = message;
+    },
+  };
+}
+
+function setBusy(value) {
+  busy = value;
+  userInput.disabled = value;
+  sendBtn.disabled = value;
+  resetBtn.disabled = value;
+  if (!value) {
+    userInput.focus();
+  }
+}
+
+// ─── Sanitizing ──────────────────────────────────────────────────────────────
+
+// Builds a function that reports what a sanitizer would strip from a string,
+// or null when there is nothing to strip. Model output has to be treated as
+// untrusted, so anything removed means the turn stops rendering.
+//
+// The native Sanitizer API is preferred; DOMPurify is only fetched when the
+// browser lacks it. The Prompt API needs Chrome 138+, which rules out the
+// incompatible setHTML() of Chrome 105-118, so a plain check is enough here.
+async function createUnsafeMarkupDetector() {
+  if (
+    typeof Element.prototype.setHTML === 'function' &&
+    typeof Sanitizer === 'function'
+  ) {
+    console.info('[prompt-api] Sanitizing with the native Sanitizer API.');
+
+    // Comments are stripped by default. They are harmless in Markdown, and
+    // treating one as an attack would be a false alarm, so allow them.
+    const sanitizer = new Sanitizer();
+    sanitizer.setComments(true);
+
+    // Both parses happen in an inert document, so nothing loads a resource or
+    // fires an event handler just because it was parsed for the comparison.
+    const inert = document.implementation.createHTMLDocument('');
+
+    return (text) => {
+      const raw = inert.createElement('div');
+      const clean = inert.createElement('div');
+      raw.innerHTML = text;
+      clean.setHTML(text, { sanitizer });
+      // setHTML() reports nothing about what it dropped, so compare a
+      // sanitized parse against an unsanitized one: any difference is
+      // something the sanitizer refused to keep.
+      if (raw.innerHTML === clean.innerHTML) {
+        return null;
+      }
+      const kept = new Set(
+        [...clean.querySelectorAll('*')].map((el) => el.localName),
+      );
+      const droppedElement = [...raw.querySelectorAll('*')]
+        .map((el) => el.localName)
+        .find((name) => !kept.has(name));
+      // No missing element means the element survived but an attribute on it
+      // did not, as with <img onerror>.
+      return droppedElement ? `<${droppedElement}>` : 'an unsafe attribute';
+    };
+  }
+
+  console.info('[prompt-api] No native Sanitizer API, falling back to DOMPurify.');
+  const { default: DOMPurify } = await import(
+    'https://cdn.jsdelivr.net/npm/dompurify@3.2.0/dist/purify.es.mjs'
+  );
+  return (text) => {
+    DOMPurify.sanitize(text);
+    if (!DOMPurify.removed.length) {
+      return null;
+    }
+    const removed = DOMPurify.removed[0];
+    const source = removed.from?.nodeName ?? removed.element?.nodeName;
+    return source ? `<${String(source).toLowerCase()}>` : 'unsafe markup';
+  };
+}
+
+const detectUnsafeMarkup = await createUnsafeMarkupDetector();
+
+// ─── Debug view ──────────────────────────────────────────────────────────────
+
+// Interface instances (LanguageModelToolCall and friends) keep their attributes
+// on the prototype, so JSON.stringify() renders them as `{}`. Copy the fields
+// out by hand to get something readable.
+function plainify(value) {
+  if (value === null || typeof value !== 'object') {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return value.map(plainify);
+  }
+  if ('callID' in value) {
+    const out = { callID: value.callID, name: value.name };
+    if ('arguments' in value) {
+      out.arguments = value.arguments;
+    }
+    if ('result' in value) {
+      out.result = Array.from(value.result ?? []).map((item) => ({
+        type: item.type,
+        value: item.value,
+      }));
+    }
+    if ('errorMessage' in value) {
+      out.errorMessage = value.errorMessage;
+    }
+    return out;
+  }
+  return Object.fromEntries(
+    Object.entries(value).map(([key, item]) => [key, plainify(item)]),
+  );
+}
+
+// Expands the shorthands the API accepts into an explicit content sequence.
+// A bare string is shorthand for `[{ type: "text", value: theString }]`.
+function asContent(value) {
+  if (typeof value === 'string') {
+    return [{ type: 'text', value }];
+  }
+  return Array.isArray(value) ? value : [value];
+}
+
+// Renders anything sent or received as canonical LanguageModelMessage objects:
+// `{ role, content: [{ type, value }] }`. prompt() takes a bare string and
+// answers with either a bare string or a content sequence, so neither leg is
+// in message form to begin with. Normalizing both means the debug view shows
+// exactly what you would store to replay the session later as
+// `initialPrompts`.
+function asMessages(role, payload) {
+  // Already a list of messages, as with the tool responses sent each round.
+  if (Array.isArray(payload) && payload.every((item) => item?.role)) {
+    return payload.map((message) => ({
+      role: message.role,
+      content: asContent(message.content),
+    }));
+  }
+  return [{ role, content: asContent(payload) }];
+}
+
+// Records one leg of the exchange: `↑` for what the page sends into the
+// session, `↓` for what the model sends back.
+function logExchange(direction, label, role, payload) {
+  const entry = document.createElement('div');
+  entry.className = `exchange ${direction}`;
+
+  const heading = document.createElement('div');
+  heading.className = 'exchange-label';
+  heading.textContent = `${direction === 'sent' ? '↑' : '↓'} ${label}`;
+  entry.append(heading);
+
+  const pre = document.createElement('pre');
+  pre.textContent = JSON.stringify(plainify(asMessages(role, payload)), null, 2);
+  entry.append(pre);
+
+  debugLog.append(entry);
+}
+
+// The system prompt opens every transcript, so a replay starts where this
+// session did.
+function logSystemPrompt() {
+  logExchange('sent', 'initialPrompts', 'system', SYSTEM_PROMPT);
+}
+
+function logTurnStart(question) {
+  const heading = document.createElement('div');
+  heading.className = 'exchange-turn';
+  heading.textContent = `Turn ${++turn}: ${question}`;
+  debugLog.append(heading);
+}
+
+// ─── Tool-call loop ──────────────────────────────────────────────────────────
+
+// Runs one tool the model asked for. Returns either the tool's parsed output
+// or a failure message, so the caller can build a tool success or a tool error.
+async function runTool(name, args) {
+  const tool = toolsByName.get(name);
+  if (!tool) {
+    // The model hallucinated a tool. Report it as a tool error rather than
+    // throwing, so it can correct itself on the next turn.
+    return { ok: false, message: `There is no tool named ${name}.` };
+  }
+
+  const entry = appendToolCall(name, args ?? {});
+  const started = performance.now();
+  try {
+    // Tools return a JSON string, so parse it back for the `object` result.
+    const parsed = JSON.parse(await tool.execute(args ?? {}));
+    entry.finish(parsed, Math.round(performance.now() - started));
+    return { ok: true, value: parsed };
+  } catch (error) {
+    entry.fail(String(error));
+    return { ok: false, message: String(error) };
+  }
+}
+
+// Builds one `tool-response` content part for a call the model made.
+//
+// The value has to be a real LanguageModelToolSuccess or LanguageModelToolError
+// instance: a plain object is rejected with "The value must be a
+// LanguageModelToolSuccess or LanguageModelToolError for type:'tool-response'".
+// Note the capital D in `callID`.
+function toolResponsePart(call, outcome) {
+  const value = outcome.ok
+    ? new LanguageModelToolSuccess({
+        callID: call.callID,
+        name: call.name,
+        // `object` takes any JSON-serializable value. Chrome currently
+        // supports only `text` and `object` here, not `image` or `audio`.
+        result: [{ type: 'object', value: outcome.value }],
+      })
+    : new LanguageModelToolError({
+        callID: call.callID,
+        name: call.name,
+        errorMessage: outcome.message,
+      });
+  return { type: 'tool-response', value };
+}
+
+// Streams one model turn.
+//
+// The stream is heterogeneous: text arrives as plain strings, while each tool
+// call arrives as its own structured `{ type: 'tool-call', value }` chunk
+// ("Each tool call becomes a separate chunk in the stream",
+// model_execution_responder.cc). Text is rendered as it arrives; tool calls are
+// collected for the caller to run.
+async function streamResponse(input) {
+  const calls = [];
+  let text = '';
+  let bubble = null;
+  let parser = null;
+
+  for await (const chunk of session.promptStreaming(input)) {
+    if (typeof chunk !== 'string') {
+      if (chunk?.type === 'tool-call') {
+        calls.push(chunk.value);
+      } else {
+        console.warn('[prompt-api] Unrecognized stream chunk:', chunk);
+        globalThis.lastChunk = chunk;
+      }
+      continue;
+    }
+
+    text += chunk;
+    // The bubble is created on the first text chunk, so a turn that only calls
+    // tools does not leave an empty one behind.
+    if (!bubble) {
+      bubble = appendMessage('assistant', '');
+      parser = smd.parser(smd.default_renderer(bubble));
+    }
+
+    // Check everything received so far, never the chunk alone: dangerous
+    // markup can be split across chunk boundaries. Anything a sanitizer would
+    // remove means the output is unsafe, so stop rendering rather than show a
+    // cleaned-up version that is no longer what the model said.
+    const unsafe = detectUnsafeMarkup(text);
+    if (unsafe) {
+      smd.parser_end(parser);
+      appendMessage(
+        'error',
+        `Rendering stopped: the sanitizer would remove ${unsafe} from this ` +
+          `response.`,
+      );
+      return { calls, parts: [], blocked: true };
+    }
+
+    // Appends only the new nodes, instead of re-parsing everything so far.
+    smd.parser_write(parser, chunk);
+  }
+
+  if (parser) {
+    smd.parser_end(parser);
+    bubble.scrollIntoView({ block: 'nearest' });
+  }
+
+  // Reassemble the turn as a canonical content sequence, so the debug view
+  // still shows a replayable message even though it arrived in pieces.
+  const parts = [];
+  if (text) {
+    parts.push({ type: 'text', value: text });
+  }
+  for (const call of calls) {
+    parts.push({ type: 'tool-call', value: call });
+  }
+  return { calls, parts, blocked: false };
+}
+
+async function ask(question) {
+  if (busy || !session) {
+    return;
+  }
+  appendMessage('user', question);
+  setBusy(true);
+  setStatus('Thinking…');
+  logTurnStart(question);
+
+  try {
+    logExchange('sent', 'promptStreaming()', 'user', question);
+    let { calls, parts, blocked } = await streamResponse(question);
+    logExchange('received', 'response', 'assistant', parts);
+    if (blocked) {
+      return;
+    }
+
+    // Keep going as long as the model asks for tools rather than just
+    // talking: run what it asked for, feed the results back, stream again.
+    let rounds = 0;
+    while (calls.length) {
+      if (++rounds > MAX_TOOL_CALLS) {
+        appendMessage(
+          'error',
+          `Stopped after ${MAX_TOOL_CALLS} tool calls without a final answer.`,
+        );
+        return;
+      }
+      setStatus(`Calling ${calls.map((call) => call.name).join(', ')}…`);
+
+      const responses = [];
+      for (const call of calls) {
+        const outcome = await runTool(call.name, call.arguments);
+        responses.push(toolResponsePart(call, outcome));
+      }
+
+      setStatus('Thinking…');
+      // Tool responses must use the user role: the role enum is only
+      // "system", "user", and "assistant". Every response for this round
+      // travels in one message.
+      const messages = [{ role: 'user', content: responses }];
+      logExchange('sent', `promptStreaming() round ${rounds}`, 'user', messages);
+      ({ calls, parts, blocked } = await streamResponse(messages));
+      logExchange('received', `response ${rounds}`, 'assistant', parts);
+      if (blocked) {
+        return;
+      }
+    }
+
+  } catch (error) {
+    appendMessage('error', `Something went wrong: ${error.message}`);
+  } finally {
+    // In `finally`, so the status is correct however the turn ended: a normal
+    // answer, a sanitizer stop, the tool-call cap, or a thrown error.
+    setStatus(
+      `Ready. Context: ${session.contextUsage} / ${session.contextWindow} tokens.`,
+    );
+    setBusy(false);
+  }
+}
+
+// ─── Session ─────────────────────────────────────────────────────────────────
+
+// Creates the pristine base session and takes the first clone from it. Called
+// straight from a click when the model still has to be downloaded, because
+// create() then needs transient user activation.
+async function createSession() {
+  activateBtn.disabled = true;
+  setStatus('Preparing the model…');
+
+  try {
+    // The base session is created once and kept pristine: it is only ever
+    // cloned, never prompted.
+    baseSession = await LanguageModel.create({
+      ...SESSION_OPTIONS,
+      initialPrompts: [{ role: 'system', content: SYSTEM_PROMPT }],
+      monitor(m) {
+        dlProgress.style.display = 'block';
+        m.addEventListener('downloadprogress', (e) => {
+          const total = e.total ?? 1;
+          dlProgress.value = e.loaded;
+          dlProgress.max = total;
+          setStatus(
+            `Downloading the model: ${Math.round((e.loaded / total) * 100)}%`,
+          );
+        });
+      },
+    });
+    session = await baseSession.clone();
+    logSystemPrompt();
+  } catch (error) {
+    dlProgress.style.display = 'none';
+    activateBtn.disabled = false;
+    setStatus(`Could not create a session: ${error.message}`);
+    return;
+  }
+
+  dlProgress.style.display = 'none';
+  activateBtn.hidden = true;
+  setStatus(
+    `Ready. Tools available: ${tools.map((tool) => tool.name).join(', ')}.`,
+  );
+  setBusy(false);
+}
+
+async function initSession() {
+  if (!('LanguageModel' in self)) {
+    setStatus(
+      'The Prompt API is not available. Use Chrome 138 or later on desktop.',
+    );
+    return;
+  }
+
+  const availability = await LanguageModel.availability(SESSION_OPTIONS);
+  if (availability === 'unavailable') {
+    setStatus('The Prompt API is not available on this device.');
+    return;
+  }
+
+  // The model is already on the device, so a session can be created right
+  // away, without any interaction.
+  if (availability === 'available') {
+    await createSession();
+    return;
+  }
+
+  // "downloadable" or "downloading": create() has to be called with transient
+  // user activation, which a page-load call does not have. Wait for a click.
+  // See https://developer.chrome.com/docs/ai/get-started#user-activation.
+  activateBtn.textContent =
+    availability === 'downloading'
+      ? 'Finish downloading the model'
+      : 'Download the model';
+  activateBtn.hidden = false;
+  activateBtn.disabled = false;
+  setStatus(
+    'The model has to be downloaded before this demo can run. Click the ' +
+      'button to start; the download is a few gigabytes and only happens once.',
+  );
+}
+
+// Throws away the conversation by destroying the clone and taking a fresh one.
+// The base session, and with it the loaded model, is untouched.
+async function resetSession() {
+  if (busy || !baseSession) {
+    return;
+  }
+  setBusy(true);
+  setStatus('Resetting session…');
+
+  session?.destroy();
+  session = await baseSession.clone();
+
+  chatEl.replaceChildren();
+  debugLog.replaceChildren();
+  logSystemPrompt();
+  turn = 0;
+  setBusy(false);
+  setStatus('Session reset. The model has forgotten the conversation.');
+}
+
+// ─── Wiring ──────────────────────────────────────────────────────────────────
+
+formEl.addEventListener('submit', (event) => {
+  event.preventDefault();
+  const question = userInput.value.trim();
+  if (!question) {
+    return;
+  }
+  userInput.value = '';
+  ask(question);
+});
+
+activateBtn.addEventListener('click', () => {
+  // The click is what grants the transient activation create() needs.
+  if (!navigator.userActivation?.isActive) {
+    setStatus('Interact with the page first, then try again.');
+    return;
+  }
+  createSession();
+});
+
+resetBtn.addEventListener('click', resetSession);
+
+for (const button of document.querySelectorAll('.example')) {
+  button.addEventListener('click', () => {
+    ask(button.textContent.trim());
+  });
+}
+
+initSession();

--- a/prompt-api-tool-use/script.js
+++ b/prompt-api-tool-use/script.js
@@ -15,6 +15,7 @@ const resetBtn = document.getElementById('reset-btn');
 const activateBtn = document.getElementById('activate-btn');
 const debugLog = document.getElementById('debug-log');
 const copyDebugBtn = document.getElementById('copy-debug');
+const flagNote = document.getElementById('flag-note');
 
 const SYSTEM_PROMPT = `You are a helpful assistant that answers questions about
 npm packages and GitHub repositories. You have tools available. Use them instead
@@ -625,6 +626,19 @@ async function initSession() {
     setStatus(
       'The Prompt API is not available. Use Chrome 138 or later on desktop.',
     );
+    return;
+  }
+
+  // These three interfaces are gated behind the same flag as tool support
+  // itself, so their absence pinpoints the flag rather than the API. Creating
+  // a session would fail anyway, since SESSION_OPTIONS asks for tool types.
+  const toolUseSupported =
+    'LanguageModelToolCall' in self &&
+    'LanguageModelToolSuccess' in self &&
+    'LanguageModelToolError' in self;
+  if (!toolUseSupported) {
+    flagNote.hidden = false;
+    setStatus('Tool use is not enabled, so this demo cannot run.');
     return;
   }
 

--- a/prompt-api-tool-use/script.js
+++ b/prompt-api-tool-use/script.js
@@ -26,8 +26,8 @@ When someone asks which package is the most popular, work through these steps
 in order:
 
 1. Call search_npm_packages once.
-2. Call get_repo_stars for every single package that search returned, one call
-   at a time, until none are left.
+2. Call get_repo_stars once, passing every single package that search returned
+   in the "repositories" array of that one call.
 3. Only once you hold a star count for every package, name the winner.
 
 Never compare star counts before you have looked all of them up, and never
@@ -354,13 +354,18 @@ function logTurnStart(question) {
 // Reports which of a tool's required arguments the model left out. Small
 // models regularly call a tool with `arguments: {}`, and running the tool
 // anyway sends undefined values to the API: a wasted request, answered with a
-// misleading error. `get_repo_stars` with no arguments asks GitHub about
-// `/repos/undefined/undefined` and reports "not found", which reads as "that
-// repository does not exist" rather than "you forgot the arguments".
+// misleading error. `get_repo_stars` with no arguments would ask GitHub about
+// nothing at all and report "not found", which reads as "that repository does
+// not exist" rather than "you forgot the arguments". An empty array counts as
+// left out for the same reason: `repositories: []` is a call with no work in
+// it.
 function missingArguments(tool, args) {
   const required = tool.inputSchema?.required ?? [];
   return required.filter((key) => {
     const value = args?.[key];
+    if (Array.isArray(value)) {
+      return value.length === 0;
+    }
     return value === undefined || value === null || value === '';
   });
 }

--- a/prompt-api-tool-use/script.js
+++ b/prompt-api-tool-use/script.js
@@ -42,8 +42,8 @@ Answer in one short paragraph. Always give the exact star counts the tools gave
 you, and never invent one.`;
 
 // The model is only told what a tool is called, what it does, and what it takes.
-// `execute()` stays on this side: the browser never runs it, the tool-call loop
-// below does.
+// `execute()` stays on the `tools.js` side: the browser never runs it, the
+// tool-call loop below does.
 const declarations = tools.map(({ name, description, inputSchema }) => ({
   name,
   description,
@@ -64,10 +64,8 @@ const toolColors = new Map(
 // warning that none was specified.
 const SESSION_OPTIONS = {
   expectedInputs: [
-    { type: 'text', languages: ['en'] },    
+    { type: 'text', languages: ['en'] },
     { type: 'tool-response' },
-    // If you want to replay a session later, tool calls become inputs.
-    { type: 'tool-call' },
   ],
   expectedOutputs: [
     { type: 'text', languages: ['en'] },
@@ -396,10 +394,9 @@ async function runTool(name, args) {
   const entry = appendToolCall(name, args ?? {});
   const started = performance.now();
   try {
-    // Tools return a JSON string, so parse it back for the `object` result.
-    const parsed = JSON.parse(await tool.execute(args ?? {}));
-    entry.finish(parsed, Math.round(performance.now() - started));
-    return { ok: true, value: parsed };
+    const result = await tool.execute(args ?? {});
+    entry.finish(result, Math.round(performance.now() - started));
+    return { ok: true, value: result };
   } catch (error) {
     entry.fail(String(error));
     return { ok: false, message: String(error) };

--- a/prompt-api-tool-use/style.css
+++ b/prompt-api-tool-use/style.css
@@ -1,0 +1,245 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright 2026 Google LLC
+ */
+
+:root {
+  color-scheme: dark light;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+body {
+  font-family: system-ui, sans-serif;
+  font-size: 14px;
+  max-width: 1028px;
+  margin: 2rem auto;
+  padding: 0 1rem;
+  color: light-dark(#111, #eee);
+}
+h1 {
+  font-size: 1.1rem;
+  margin-bottom: 0.25rem;
+}
+p.subtitle {
+  color: light-dark(#555, #aaa);
+  margin-bottom: 1.25rem;
+  max-width: 70ch;
+}
+
+/* Status bar */
+#status {
+  padding: 0.4rem 0.6rem;
+  background: light-dark(#f4f4f4, #222);
+  border: 1px solid light-dark(#ddd, #444);
+  margin-bottom: 0.75rem;
+}
+
+/* Download progress */
+#dl-progress {
+  width: 100%;
+  display: none;
+  margin-bottom: 0.75rem;
+}
+
+/* Example prompts */
+#examples {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  margin-bottom: 1rem;
+}
+button.example {
+  font: inherit;
+  color: inherit;
+  text-align: left;
+  padding: 0.35rem 0.6rem;
+  background: light-dark(#fff, #1b1b1b);
+  border: 1px solid light-dark(#ccc, #555);
+  border-radius: 999px;
+  cursor: pointer;
+}
+button.example:hover {
+  background: light-dark(#f0f0f0, #2a2a2a);
+}
+
+/* Chat */
+#chat {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  margin-bottom: 1rem;
+}
+.message {
+  padding: 0.5rem 0.7rem;
+  border: 1px solid light-dark(#ddd, #444);
+  white-space: pre-wrap;
+  max-width: 70ch;
+}
+.message.user {
+  align-self: flex-end;
+  background: light-dark(#eef3ff, #1e2637);
+  border-color: light-dark(#c6d4f5, #33456b);
+}
+.message.assistant {
+  background: light-dark(#fff, #1b1b1b);
+  /* Streamed Markdown is rendered to real elements, so the pre-wrap used for
+     plain messages would double up the whitespace. */
+  white-space: normal;
+}
+/* The global reset strips margins, so the Markdown elements need their own. */
+.message.assistant :is(p, ul, ol, pre, blockquote, table) {
+  margin-bottom: 0.6rem;
+}
+.message.assistant :is(h1, h2, h3, h4) {
+  font-size: 1rem;
+  margin-bottom: 0.4rem;
+}
+.message.assistant :is(ul, ol) {
+  padding-left: 1.2rem;
+}
+.message.assistant li {
+  margin-bottom: 0.2rem;
+}
+.message.assistant > :last-child {
+  margin-bottom: 0;
+}
+.message.assistant :is(code, pre) {
+  font-family: ui-monospace, monospace;
+  font-size: 12px;
+}
+.message.assistant code {
+  background: light-dark(#f0f0f0, #2a2a2a);
+  padding: 0.1em 0.3em;
+}
+.message.assistant pre {
+  background: light-dark(#f6f6f6, #222);
+  padding: 0.5rem;
+  overflow-x: auto;
+}
+.message.assistant pre code {
+  background: none;
+  padding: 0;
+}
+.message.assistant a {
+  color: light-dark(#1a56b8, #7fb0f2);
+}
+.message.error {
+  background: light-dark(#fff0f0, #331d1d);
+  border-color: light-dark(#e0b4b4, #6b3333);
+}
+
+/* Tool calls */
+.tool-call {
+  border-left: 3px solid light-dark(#8a6d00, #d9b64a);
+  background: light-dark(#fffaf0, #241f14);
+  padding: 0.4rem 0.6rem;
+  font-family: ui-monospace, monospace;
+  font-size: 12px;
+}
+.tool-call summary {
+  cursor: pointer;
+  color: light-dark(#8a6d00, #d9b64a);
+}
+.tool-call pre {
+  margin-top: 0.4rem;
+  max-height: 14rem;
+  overflow: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+/* Composer */
+#composer {
+  display: flex;
+  gap: 0.5rem;
+}
+#user-input {
+  flex: 1;
+  font: inherit;
+  color: inherit;
+  padding: 0.5rem 0.6rem;
+  background: light-dark(#fff, #1b1b1b);
+  border: 1px solid light-dark(#ccc, #555);
+}
+#send-btn {
+  font: inherit;
+  padding: 0.5rem 1rem;
+  cursor: pointer;
+}
+#send-btn:disabled,
+#user-input:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* Controls */
+#controls {
+  display: flex;
+  gap: 0.5rem;
+  align-items: stretch;
+  margin-bottom: 0.75rem;
+}
+#controls #status {
+  flex: 1;
+  margin-bottom: 0;
+}
+#reset-btn,
+#activate-btn {
+  font: inherit;
+  padding: 0.4rem 0.8rem;
+  cursor: pointer;
+  white-space: nowrap;
+}
+#reset-btn:disabled,
+#activate-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* Debug view */
+#debug {
+  margin-top: 1.5rem;
+  border-top: 1px solid light-dark(#ddd, #444);
+  padding-top: 0.75rem;
+}
+#debug > summary {
+  cursor: pointer;
+  color: light-dark(#555, #aaa);
+}
+#debug-log {
+  margin-top: 0.75rem;
+  font-family: ui-monospace, monospace;
+  font-size: 12px;
+}
+.exchange-turn {
+  margin: 1rem 0 0.5rem;
+  padding-bottom: 0.2rem;
+  border-bottom: 1px solid light-dark(#ddd, #444);
+  font-weight: bold;
+}
+.exchange {
+  margin-bottom: 0.5rem;
+  padding: 0.3rem 0.5rem;
+  border-left: 3px solid transparent;
+  background: light-dark(#f7f7f7, #1b1b1b);
+}
+.exchange.sent {
+  border-left-color: light-dark(#3b6ea5, #6f9fd8);
+}
+.exchange.received {
+  border-left-color: light-dark(#3f7d51, #7bbf8e);
+}
+.exchange-label {
+  color: light-dark(#555, #aaa);
+  margin-bottom: 0.2rem;
+}
+.exchange pre {
+  max-height: 18rem;
+  overflow: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
+}

--- a/prompt-api-tool-use/style.css
+++ b/prompt-api-tool-use/style.css
@@ -30,11 +30,12 @@ p.subtitle {
   max-width: 70ch;
 }
 
-/* Status bar */
+/* Status line */
 #status {
-  padding: 0.4rem 0.6rem;
-  background: light-dark(#f4f4f4, #222);
-  border: 1px solid light-dark(#ddd, #444);
+  /* Deliberately not a box: bordered and filled, stretched across the row
+     next to a button, it read as a text field the user could type into. */
+  color: light-dark(#555, #aaa);
+  padding: 0.4rem 0;
   margin-bottom: 0.75rem;
 }
 
@@ -74,18 +75,28 @@ button.example:hover {
   margin-bottom: 1rem;
 }
 .message {
-  padding: 0.5rem 0.7rem;
+  padding: 0.5rem 0.9rem;
   border: 1px solid light-dark(#ddd, #444);
+  /* Matched to half a single line's height, so a one-line message comes out
+     as a pill like the example buttons, and a longer one stays rounded
+     instead of turning into a stadium. */
+  border-radius: 1rem;
   white-space: pre-wrap;
   max-width: 70ch;
 }
 .message.user {
   align-self: flex-end;
-  background: light-dark(#eef3ff, #1e2637);
-  border-color: light-dark(#c6d4f5, #33456b);
+  background: light-dark(#e8eeff, #1d2740);
+  border-color: light-dark(#bfd0f5, #35497a);
+  /* The corner on the sender's side is tightened, so the two sides of the
+     conversation lean away from each other. */
+  border-bottom-right-radius: 0.25rem;
 }
 .message.assistant {
-  background: light-dark(#fff, #1b1b1b);
+  align-self: flex-start;
+  background: light-dark(#f0f7f2, #16231b);
+  border-color: light-dark(#c8e0d1, #2d4735);
+  border-bottom-left-radius: 0.25rem;
   /* Streamed Markdown is rendered to real elements, so the pre-wrap used for
      plain messages would double up the whitespace. */
   white-space: normal;
@@ -128,21 +139,59 @@ button.example:hover {
   color: light-dark(#1a56b8, #7fb0f2);
 }
 .message.error {
+  align-self: flex-start;
   background: light-dark(#fff0f0, #331d1d);
   border-color: light-dark(#e0b4b4, #6b3333);
+  border-bottom-left-radius: 0.25rem;
 }
 
 /* Tool calls */
 .tool-call {
-  border-left: 3px solid light-dark(#8a6d00, #d9b64a);
-  background: light-dark(#fffaf0, #241f14);
+  /* Neutral default, used by a tool the model invented. Each declared tool
+     overrides these two below, keyed by its color slot. */
+  --tool-ink: light-dark(#555, #aaa);
+  --tool-bg: light-dark(#f6f6f6, #1e1e1e);
+  border-left: 3px solid var(--tool-ink);
+  background: var(--tool-bg);
   padding: 0.4rem 0.6rem;
   font-family: ui-monospace, monospace;
   font-size: 12px;
 }
 .tool-call summary {
   cursor: pointer;
-  color: light-dark(#8a6d00, #d9b64a);
+  color: var(--tool-ink);
+}
+
+/* One slot per tool, assigned in declaration order. */
+.tool-call[data-tool='0'] {
+  --tool-ink: light-dark(#8a6d00, #d9b64a);
+  --tool-bg: light-dark(#fffaf0, #241f14);
+}
+.tool-call[data-tool='1'] {
+  --tool-ink: light-dark(#12667f, #6cc3e0);
+  --tool-bg: light-dark(#f0fafd, #14212a);
+}
+.tool-call[data-tool='2'] {
+  --tool-ink: light-dark(#6b3f9e, #b998e8);
+  --tool-bg: light-dark(#faf5ff, #1f1a2b);
+}
+.tool-call[data-tool='3'] {
+  --tool-ink: light-dark(#2c7a4b, #7fce9c);
+  --tool-bg: light-dark(#f2fbf6, #16241c);
+}
+.tool-call[data-tool='4'] {
+  --tool-ink: light-dark(#a5457a, #eb9cc6);
+  --tool-bg: light-dark(#fff5fa, #2a1722);
+}
+.tool-call[data-tool='5'] {
+  --tool-ink: light-dark(#9c5518, #e0a86c);
+  --tool-bg: light-dark(#fff7f0, #2a1d14);
+}
+
+/* A failed call is a failure first and a tool second. */
+.tool-call.failed {
+  --tool-ink: light-dark(#b03030, #e07070);
+  --tool-bg: light-dark(#fff5f5, #2a1616);
 }
 .tool-call pre {
   margin-top: 0.4rem;
@@ -180,7 +229,9 @@ button.example:hover {
 #controls {
   display: flex;
   gap: 0.5rem;
-  align-items: stretch;
+  /* Center, so the status text sits with the buttons rather than stretching
+     to their height. */
+  align-items: center;
   margin-bottom: 0.75rem;
 }
 #controls #status {

--- a/prompt-api-tool-use/style.css
+++ b/prompt-api-tool-use/style.css
@@ -170,8 +170,8 @@ button.example:hover {
   padding: 0.5rem 1rem;
   cursor: pointer;
 }
-#send-btn:disabled,
-#user-input:disabled {
+#send-btn[aria-disabled='true'],
+#user-input[aria-disabled='true'] {
   opacity: 0.5;
   cursor: not-allowed;
 }
@@ -194,8 +194,8 @@ button.example:hover {
   cursor: pointer;
   white-space: nowrap;
 }
-#reset-btn:disabled,
-#activate-btn:disabled {
+#reset-btn[aria-disabled='true'],
+#activate-btn[aria-disabled='true'] {
   opacity: 0.5;
   cursor: not-allowed;
 }
@@ -242,4 +242,17 @@ button.example:hover {
   overflow: auto;
   white-space: pre-wrap;
   word-break: break-word;
+}
+
+#debug-toolbar {
+  margin-top: 0.75rem;
+}
+#copy-debug {
+  font: inherit;
+  padding: 0.3rem 0.6rem;
+  cursor: pointer;
+}
+
+.exchange.failed {
+  border-left-color: light-dark(#b03030, #e07070);
 }

--- a/prompt-api-tool-use/style.css
+++ b/prompt-api-tool-use/style.css
@@ -29,6 +29,21 @@ p.subtitle {
   margin-bottom: 1.25rem;
   max-width: 70ch;
 }
+/* A prerequisite, not prose: set apart from the description above it so it
+   does not read as one more sentence about the demo. */
+p.requirement {
+  max-width: 70ch;
+  margin-bottom: 1.25rem;
+  padding: 0.5rem 0.7rem;
+  border-left: 3px solid light-dark(#8a6d00, #d9b64a);
+  background: light-dark(#fffaf0, #241f14);
+}
+p.requirement code {
+  font-family: ui-monospace, monospace;
+  font-size: 12px;
+  background: light-dark(#f4ecd8, #332c1a);
+  padding: 0.1em 0.35em;
+}
 
 /* Status line */
 #status {

--- a/prompt-api-tool-use/tools.js
+++ b/prompt-api-tool-use/tools.js
@@ -63,7 +63,7 @@ async function getRepoStars({ owner, repo }) {
   });
 }
 
-async function searchNpmPackages({ query, limit = 5 }) {
+async function searchNpmPackages({ query, limit = 3 }) {
   // npm normalizes repository links to a handful of shapes, all of which
   // need to collapse to a plain `owner/repo` pair so the result can be handed
   // straight to `get_repo_stars`:
@@ -91,7 +91,9 @@ async function searchNpmPackages({ query, limit = 5 }) {
     return { owner, repo };
   }
 
-  const count = Math.min(Math.max(Number(limit) || 5, 1), 10);
+  // Default deliberately low: every extra package is another round trip the
+  // model has to complete before it can compare, and it tends to give up.
+  const count = Math.min(Math.max(Number(limit) || 3, 1), 10);
   // Over-fetch, because packages without a GitHub repository are dropped
   // below and would otherwise leave the list short.
   const size = Math.min(count * 4, 50);
@@ -186,7 +188,9 @@ export const tools = [
       'Search the npm registry for packages matching a query, for example ' +
       '"browser fs access". Only returns packages that have an associated ' +
       'GitHub repository. Use this to find candidate packages, then look up ' +
-      "a package's popularity with get_repo_stars. A package marked " +
+      "a package's popularity with get_repo_stars. Comparing packages means " +
+      'calling get_repo_stars once for each package this returns, not just ' +
+      'for the first one. A package marked ' +
       '"sharedRepository": true lives inside a repository that holds several ' +
       'packages, so that repository\'s star count covers all of them and is ' +
       'not a measure of that one package. Say so whenever you report or ' +
@@ -203,7 +207,8 @@ export const tools = [
         limit: {
           type: 'number',
           description:
-            'How many packages to return. Defaults to 5, at most 10.',
+            'How many packages to return. Defaults to 3, at most 10. Keep ' +
+            'this small: each package costs another get_repo_stars call.',
         },
       },
       required: ['query'],

--- a/prompt-api-tool-use/tools.js
+++ b/prompt-api-tool-use/tools.js
@@ -1,0 +1,208 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Google LLC
+
+// Tools the model can call, split into two halves:
+//
+//   1. The implementations below, which do the actual work.
+//   2. The declarations exported at the bottom, which describe each tool to
+//      the model: its `name`, `description`, and `inputSchema`.
+//
+// Only the declarations reach the model. `execute()` stays on this side, so
+// the split mirrors what actually crosses that boundary.
+//
+// Both APIs are called unauthenticated, so no API key is needed. GitHub's
+// limit is then 60 requests per hour and per IP address.
+
+const GITHUB_API = 'https://api.github.com';
+const NPM_REGISTRY = 'https://registry.npmjs.org';
+
+// ─── Implementations ─────────────────────────────────────────────────────────
+
+// Every implementation returns its result as a JSON string, and reports
+// failures as a returned `{ error, message }` rather than by throwing, so the
+// model can tell the user what went wrong instead of the turn dying.
+
+async function getRepoStars({ owner, repo }) {
+  const path =
+    `/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}`;
+  const response = await fetch(`${GITHUB_API}${path}`, {
+    headers: {
+      Accept: 'application/vnd.github+json',
+      'X-GitHub-Api-Version': '2022-11-28',
+    },
+  });
+
+  if (!response.ok) {
+    if (response.status === 404) {
+      return JSON.stringify({
+        error: 'not_found',
+        message: `There is no repository at ${owner}/${repo}.`,
+      });
+    }
+    if (response.status === 403 || response.status === 429) {
+      return JSON.stringify({
+        error: 'rate_limited',
+        message: 'The GitHub API rate limit is exhausted. Try again later.',
+      });
+    }
+    return JSON.stringify({
+      error: 'request_failed',
+      message: `The GitHub API responded with ${response.status}.`,
+    });
+  }
+
+  // Only the fields the model needs. Everything returned here ends up in the
+  // session's context window, so keep the payload small.
+  const data = await response.json();
+  return JSON.stringify({
+    repository: data.full_name,
+    stars: data.stargazers_count,
+    forks: data.forks_count,
+    description: data.description,
+    url: data.html_url,
+  });
+}
+
+async function searchNpmPackages({ query, limit = 5 }) {
+  // npm normalizes repository links to a handful of shapes, all of which
+  // need to collapse to a plain `owner/repo` pair so the result can be handed
+  // straight to `get_repo_stars`:
+  //
+  //   git+https://github.com/owner/repo.git
+  //   git+ssh://git@github.com/owner/repo.git
+  //   https://github.com/owner/repo/tree/main/packages/sub   (monorepo package)
+  //   github:owner/repo
+  function parseGitHubRepo(url) {
+    if (!url) {
+      return null;
+    }
+    const shorthand = url.match(/^github:([^/]+)\/(.+)$/);
+    const match = shorthand
+      ? shorthand
+      : url.match(/github\.com[/:]([^/]+)\/([^/#?]+)/);
+    if (!match) {
+      return null;
+    }
+    const owner = match[1];
+    const repo = match[2].replace(/\.git$/, '');
+    if (!owner || !repo) {
+      return null;
+    }
+    return { owner, repo };
+  }
+
+  const count = Math.min(Math.max(Number(limit) || 5, 1), 10);
+  // Over-fetch, because packages without a GitHub repository are dropped
+  // below and would otherwise leave the list short.
+  const size = Math.min(count * 4, 50);
+  const url =
+    `${NPM_REGISTRY}/-/v1/search` +
+    `?text=${encodeURIComponent(query)}&size=${size}`;
+
+  let data;
+  try {
+    const response = await fetch(url);
+    if (!response.ok) {
+      return JSON.stringify({
+        error: 'request_failed',
+        message: `The npm registry responded with ${response.status}.`,
+      });
+    }
+    data = await response.json();
+  } catch {
+    return JSON.stringify({
+      error: 'request_failed',
+      message: 'The npm registry could not be reached.',
+    });
+  }
+
+  const packages = [];
+  for (const object of data.objects ?? []) {
+    const pkg = object.package;
+    const gitHub = parseGitHubRepo(pkg.links?.repository);
+    // The filter the tool promises: no GitHub repository, no result.
+    if (!gitHub) {
+      continue;
+    }
+    packages.push({
+      name: pkg.name,
+      version: pkg.version,
+      description: pkg.description,
+      // Split out so the model can pass these straight to get_repo_stars.
+      owner: gitHub.owner,
+      repo: gitHub.repo,
+      npmUrl: pkg.links?.npm,
+    });
+    if (packages.length === count) {
+      break;
+    }
+  }
+
+  if (packages.length === 0) {
+    return JSON.stringify({
+      error: 'no_results',
+      message: `No npm packages with a GitHub repository matched "${query}".`,
+    });
+  }
+  return JSON.stringify({ query, packages });
+}
+
+// ─── Declarations ────────────────────────────────────────────────────────────
+
+// This is everything the model is told about the tools. The wording is part of
+// the prompt: it is what the model reasons over when deciding which tool to
+// call and what to pass it.
+
+export const tools = [
+  {
+    name: 'search_npm_packages',
+    description:
+      'Search the npm registry for packages matching a query, for example ' +
+      '"browser fs access". Only returns packages that have an associated ' +
+      'GitHub repository. Use this to find candidate packages, then look up ' +
+      "a package's popularity with get_repo_stars.",
+    inputSchema: {
+      type: 'object',
+      properties: {
+        query: {
+          type: 'string',
+          description:
+            'What to search for, for example "browser fs access" or "date ' +
+            'formatting".',
+        },
+        limit: {
+          type: 'number',
+          description:
+            'How many packages to return. Defaults to 5, at most 10.',
+        },
+      },
+      required: ['query'],
+    },
+    execute: searchNpmPackages,
+  },
+  {
+    name: 'get_repo_stars',
+    description:
+      'Get the number of GitHub stars a repository has. Use this whenever ' +
+      'someone asks how popular a repository is or how many stars it has.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        owner: {
+          type: 'string',
+          description:
+            'The user or organization that owns the repository, for example ' +
+            '"GoogleChromeLabs".',
+        },
+        repo: {
+          type: 'string',
+          description:
+            'The name of the repository without the owner, for example ' +
+            '"web-ai-demos".',
+        },
+      },
+      required: ['owner', 'repo'],
+    },
+    execute: getRepoStars,
+  },
+];

--- a/prompt-api-tool-use/tools.js
+++ b/prompt-api-tool-use/tools.js
@@ -16,51 +16,115 @@
 const GITHUB_API = 'https://api.github.com';
 const NPM_REGISTRY = 'https://registry.npmjs.org';
 
+// How many packages one search returns at most, and how many repositories one
+// `get_repo_stars` call looks up. Every repository is a separate GitHub
+// request against that hourly quota of 60.
+const MAX_REPOS = 10;
+
 // ─── Implementations ─────────────────────────────────────────────────────────
 
 // Every implementation returns its result as a JSON string, and reports
 // failures as a returned `{ error, message }` rather than by throwing, so the
 // model can tell the user what went wrong instead of the turn dying.
 
-async function getRepoStars({ owner, repo }) {
+// One repository, as its own object. Failures come back as an `{ error,
+// message }` entry rather than sinking the whole batch: one repository that has
+// been renamed should not cost the model the other nine star counts.
+async function fetchRepoStars({ owner, repo }) {
   const path =
     `/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}`;
-  const response = await fetch(`${GITHUB_API}${path}`, {
-    headers: {
-      Accept: 'application/vnd.github+json',
-      'X-GitHub-Api-Version': '2022-11-28',
-    },
-  });
+  let response;
+  try {
+    response = await fetch(`${GITHUB_API}${path}`, {
+      headers: {
+        Accept: 'application/vnd.github+json',
+        'X-GitHub-Api-Version': '2022-11-28',
+      },
+    });
+  } catch {
+    return {
+      owner,
+      repo,
+      error: 'request_failed',
+      message: 'The GitHub API could not be reached.',
+    };
+  }
 
   if (!response.ok) {
     if (response.status === 404) {
-      return JSON.stringify({
+      return {
+        owner,
+        repo,
         error: 'not_found',
         message: `There is no repository at ${owner}/${repo}.`,
-      });
+      };
     }
     if (response.status === 403 || response.status === 429) {
-      return JSON.stringify({
+      return {
+        owner,
+        repo,
         error: 'rate_limited',
         message: 'The GitHub API rate limit is exhausted. Try again later.',
-      });
+      };
     }
-    return JSON.stringify({
+    return {
+      owner,
+      repo,
       error: 'request_failed',
       message: `The GitHub API responded with ${response.status}.`,
-    });
+    };
   }
 
   // Only the fields the model needs. Everything returned here ends up in the
   // session's context window, so keep the payload small.
   const data = await response.json();
-  return JSON.stringify({
+  return {
     repository: data.full_name,
     stars: data.stargazers_count,
     forks: data.forks_count,
     description: data.description,
     url: data.html_url,
-  });
+  };
+}
+
+// Takes a whole list of repositories, because comparing packages is the point:
+// one repository per tool call means a round trip through the model for each,
+// and a small model tends to lose the thread and answer from the first star
+// count it saw. One call, one comparison.
+//
+// GitHub has no batch endpoint, so this still makes one request per repository,
+// just in parallel. The saving is in model round trips, not in HTTP requests:
+// the unauthenticated rate limit of 60 requests per hour still counts every
+// repository separately.
+async function getRepoStars({ repositories, owner, repo }) {
+  // A single `{ owner, repo }` pair is accepted as well. The schema asks for an
+  // array, but small models regularly send the shape the question had instead,
+  // and a demo that answers "wrong arguments" there teaches nothing.
+  const requested = Array.isArray(repositories)
+    ? repositories
+    : repositories
+      ? [repositories]
+      : owner || repo
+        ? [{ owner, repo }]
+        : [];
+
+  const wanted = requested.filter((entry) => entry?.owner && entry?.repo);
+  if (wanted.length === 0) {
+    return JSON.stringify({
+      error: 'invalid_arguments',
+      message:
+        'Call get_repo_stars with a "repositories" array whose entries each ' +
+        'have an "owner" and a "repo", for example ' +
+        '[{"owner": "GoogleChromeLabs", "repo": "web-ai-demos"}].',
+    });
+  }
+
+  // Capped at what one search can return, so a search result can always be
+  // looked up in a single call and a runaway list cannot burn the hourly quota.
+  const results = await Promise.all(
+    wanted.slice(0, MAX_REPOS).map(fetchRepoStars),
+  );
+  return JSON.stringify({ repositories: results });
 }
 
 async function searchNpmPackages({ query, limit = 3 }) {
@@ -91,9 +155,9 @@ async function searchNpmPackages({ query, limit = 3 }) {
     return { owner, repo };
   }
 
-  // Default deliberately low: every extra package is another round trip the
-  // model has to complete before it can compare, and it tends to give up.
-  const count = Math.min(Math.max(Number(limit) || 3, 1), 10);
+  // Default deliberately low: every extra package is another GitHub request
+  // against the hourly quota, and another entry in the context window.
+  const count = Math.min(Math.max(Number(limit) || 3, 1), MAX_REPOS);
   // Over-fetch, because packages without a GitHub repository are dropped
   // below and would otherwise leave the list short.
   const size = Math.min(count * 4, 50);
@@ -188,9 +252,9 @@ export const tools = [
       'Search the npm registry for packages matching a query, for example ' +
       '"browser fs access". Only returns packages that have an associated ' +
       'GitHub repository. Use this to find candidate packages, then look up ' +
-      "a package's popularity with get_repo_stars. Comparing packages means " +
-      'calling get_repo_stars once for each package this returns, not just ' +
-      'for the first one. A package marked ' +
+      "their popularity with get_repo_stars. Comparing packages means passing " +
+      'every package this returns to get_repo_stars in one call, not just the ' +
+      'first one. A package marked ' +
       '"sharedRepository": true lives inside a repository that holds several ' +
       'packages, so that repository\'s star count covers all of them and is ' +
       'not a measure of that one package. Say so whenever you report or ' +
@@ -208,7 +272,7 @@ export const tools = [
           type: 'number',
           description:
             'How many packages to return. Defaults to 3, at most 10. Keep ' +
-            'this small: each package costs another get_repo_stars call.',
+            'this small: every package is another GitHub lookup.',
         },
       },
       required: ['query'],
@@ -218,28 +282,42 @@ export const tools = [
   {
     name: 'get_repo_stars',
     description:
-      'Get the number of GitHub stars a repository has. Use this whenever ' +
-      'someone asks how popular a repository is or how many stars it has. ' +
-      'Stars belong to the repository as a whole, so if the repository holds ' +
-      'more than one package, the count is not a measure of any single one ' +
-      'of them.',
+      'Get the number of GitHub stars one or more repositories have. Use ' +
+      'this whenever someone asks how popular a repository is or how many ' +
+      'stars it has. Pass every repository you want to compare in a single ' +
+      'call, up to 10 at a time, rather than calling this once per ' +
+      'repository. Stars belong to the repository as a whole, so if the ' +
+      'repository holds more than one package, the count is not a measure of ' +
+      'any single one of them.',
     inputSchema: {
       type: 'object',
       properties: {
-        owner: {
-          type: 'string',
+        repositories: {
+          type: 'array',
           description:
-            'The user or organization that owns the repository, for example ' +
-            '"GoogleChromeLabs".',
-        },
-        repo: {
-          type: 'string',
-          description:
-            'The name of the repository without the owner, for example ' +
-            '"web-ai-demos".',
+            'The repositories to look up, all of them in this one call, for ' +
+            'example [{"owner": "GoogleChromeLabs", "repo": "web-ai-demos"}].',
+          items: {
+            type: 'object',
+            properties: {
+              owner: {
+                type: 'string',
+                description:
+                  'The user or organization that owns the repository, for ' +
+                  'example "GoogleChromeLabs".',
+              },
+              repo: {
+                type: 'string',
+                description:
+                  'The name of the repository without the owner, for ' +
+                  'example "web-ai-demos".',
+              },
+            },
+            required: ['owner', 'repo'],
+          },
         },
       },
-      required: ['owner', 'repo'],
+      required: ['repositories'],
     },
     execute: getRepoStars,
   },

--- a/prompt-api-tool-use/tools.js
+++ b/prompt-api-tool-use/tools.js
@@ -138,6 +138,32 @@ async function searchNpmPackages({ query, limit = 5 }) {
     }
   }
 
+  // The search endpoint drops `repository.directory`, so ask the registry for
+  // each candidate. A directory means the package sits in a subdirectory of a
+  // larger repository, and that repository's stars are not the package's
+  // stars: `prompt-api-polyfill` lives in `GoogleChromeLabs/web-ai-demos`,
+  // whose stars cover every demo in it. Fetched in parallel, and best effort:
+  // a package that cannot be checked is simply left unflagged.
+  await Promise.all(
+    packages.map(async (pkg) => {
+      try {
+        // Scoped names keep their `@`, but the slash has to be escaped.
+        const response = await fetch(
+          `${NPM_REGISTRY}/${pkg.name.replace('/', '%2F')}/latest`,
+        );
+        if (!response.ok) {
+          return;
+        }
+        const doc = await response.json();
+        if (doc.repository?.directory) {
+          pkg.sharedRepository = true;
+        }
+      } catch {
+        // Leave the package unflagged.
+      }
+    }),
+  );
+
   if (packages.length === 0) {
     return JSON.stringify({
       error: 'no_results',
@@ -160,7 +186,11 @@ export const tools = [
       'Search the npm registry for packages matching a query, for example ' +
       '"browser fs access". Only returns packages that have an associated ' +
       'GitHub repository. Use this to find candidate packages, then look up ' +
-      "a package's popularity with get_repo_stars.",
+      "a package's popularity with get_repo_stars. A package marked " +
+      '"sharedRepository": true lives inside a repository that holds several ' +
+      'packages, so that repository\'s star count covers all of them and is ' +
+      'not a measure of that one package. Say so whenever you report or ' +
+      'compare stars for such a package.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -184,7 +214,10 @@ export const tools = [
     name: 'get_repo_stars',
     description:
       'Get the number of GitHub stars a repository has. Use this whenever ' +
-      'someone asks how popular a repository is or how many stars it has.',
+      'someone asks how popular a repository is or how many stars it has. ' +
+      'Stars belong to the repository as a whole, so if the repository holds ' +
+      'more than one package, the count is not a measure of any single one ' +
+      'of them.',
     inputSchema: {
       type: 'object',
       properties: {

--- a/prompt-api-tool-use/tools.js
+++ b/prompt-api-tool-use/tools.js
@@ -23,7 +23,7 @@ const MAX_REPOS = 10;
 
 // ─── Implementations ─────────────────────────────────────────────────────────
 
-// Every implementation returns its result as a JSON string, and reports
+// Every implementation returns its result as a JavaScript object, and reports
 // failures as a returned `{ error, message }` rather than by throwing, so the
 // model can tell the user what went wrong instead of the turn dying.
 
@@ -110,13 +110,13 @@ async function getRepoStars({ repositories, owner, repo }) {
 
   const wanted = requested.filter((entry) => entry?.owner && entry?.repo);
   if (wanted.length === 0) {
-    return JSON.stringify({
+    return {
       error: 'invalid_arguments',
       message:
         'Call get_repo_stars with a "repositories" array whose entries each ' +
         'have an "owner" and a "repo", for example ' +
         '[{"owner": "GoogleChromeLabs", "repo": "web-ai-demos"}].',
-    });
+    };
   }
 
   // Capped at what one search can return, so a search result can always be
@@ -124,7 +124,7 @@ async function getRepoStars({ repositories, owner, repo }) {
   const results = await Promise.all(
     wanted.slice(0, MAX_REPOS).map(fetchRepoStars),
   );
-  return JSON.stringify({ repositories: results });
+  return { repositories: results };
 }
 
 async function searchNpmPackages({ query, limit = 3 }) {
@@ -169,17 +169,17 @@ async function searchNpmPackages({ query, limit = 3 }) {
   try {
     const response = await fetch(url);
     if (!response.ok) {
-      return JSON.stringify({
+      return {
         error: 'request_failed',
         message: `The npm registry responded with ${response.status}.`,
-      });
+      };
     }
     data = await response.json();
   } catch {
-    return JSON.stringify({
+    return {
       error: 'request_failed',
       message: 'The npm registry could not be reached.',
-    });
+    };
   }
 
   const packages = [];
@@ -231,12 +231,12 @@ async function searchNpmPackages({ query, limit = 3 }) {
   );
 
   if (packages.length === 0) {
-    return JSON.stringify({
+    return {
       error: 'no_results',
       message: `No npm packages with a GitHub repository matched "${query}".`,
-    });
+    };
   }
-  return JSON.stringify({ query, packages });
+  return { query, packages };
 }
 
 // ─── Declarations ────────────────────────────────────────────────────────────

--- a/prompt-api-tool-use/tools.js
+++ b/prompt-api-tool-use/tools.js
@@ -322,3 +322,10 @@ export const tools = [
     execute: getRepoStars,
   },
 ];
+
+// Register the tools for WebMCP, if the browser supports it.
+if ('modelContext' in document) {
+  for (const tool of tools) {
+    await document.modelContext.registerTool(tool);
+  }
+}


### PR DESCRIPTION
Demonstrates tool use with the Prompt API: the model is given two tools, one that searches npm for packages with an associated GitHub repository and one that looks up a repository's star count, then chains them to answer questions like "which npm package for browser fs access is the most popular on GitHub?".

Uses `promptStreaming()` with a streaming Markdown renderer, and includes a debug view showing the full message exchange in canonical `LanguageModelMessage` form.

<img width="715" height="1189" alt="tool-use" src="https://github.com/user-attachments/assets/d4530dad-a531-4302-9343-9f8c70da1daf" />
