### PR TITLE
[DO NOT MERGE YET] Don't fall back to the Prompt API polyfill for Writer and Rewriter

### DIFF
--- a/built-in-ai-task-apis-polyfills/README.md
+++ b/built-in-ai-task-apis-polyfills/README.md
@@ -11,12 +11,17 @@ specifically:
 - **Translator API**
 - **SemanticEmbedder API**
 
-The Summarizer, Writer, Rewriter, Language Detector, and Translator polyfills
-are backed by the
+The Summarizer, Language Detector, and Translator polyfills are backed by the
 [`prompt-api-polyfill`](https://github.com/GoogleChromeLabs/web-ai-demos/tree/main/prompt-api-polyfill),
 which is automatically loaded if `window.LanguageModel` is not detected. This
 means they support the same
 [dynamic backends](https://github.com/GoogleChromeLabs/web-ai-demos/tree/main/prompt-api-polyfill#supported-backends).
+
+The Writer and Rewriter polyfills are backed by `window.LanguageModel` as well,
+but they never load the `prompt-api-polyfill`. If the browser does not expose
+the LanguageModel API, `Writer.availability()` and `Rewriter.availability()`
+resolve with `'unavailable'`, and `Writer.create()` and `Rewriter.create()`
+reject with a `NotSupportedError`.
 
 The SemanticEmbedder polyfill is backed by
 [EmbeddingGemma 300M](https://huggingface.co/onnx-community/embeddinggemma-300m-ONNX)

--- a/built-in-ai-task-apis-polyfills/base-task-model.js
+++ b/built-in-ai-task-apis-polyfills/base-task-model.js
@@ -14,6 +14,13 @@ export class BaseTaskModel {
   #destructionController = new AbortController();
   #destructionReason = null;
 
+  /**
+   * Whether the Prompt API polyfill may be loaded to back this API when the
+   * LanguageModel API is missing. Subclasses that must not fall back to it set
+   * this to `false`.
+   */
+  static _canUsePromptApiPolyfill = true;
+
   constructor(session, builder) {
     this.#session = session;
     this.#builder = builder;
@@ -67,7 +74,9 @@ export class BaseTaskModel {
       return p;
     }
     const p = (async () => {
-      await this.ensureLanguageModel();
+      if (!(await this.ensureLanguageModel())) {
+        return 'unavailable';
+      }
       const lmOptions = {
         expectedInputs: [
           {
@@ -92,17 +101,32 @@ export class BaseTaskModel {
     return p;
   }
 
+  /**
+   * Makes sure a LanguageModel implementation is available, loading the Prompt
+   * API polyfill if the API is missing and this API is allowed to fall back to
+   * it.
+   * @returns {Promise<boolean>} Whether a LanguageModel is available.
+   */
   static async ensureLanguageModel() {
     const win = this.__window || globalThis;
-    if (typeof win !== 'undefined' && !win.LanguageModel) {
+    if (typeof win === 'undefined') {
+      return false;
+    }
+    if (!win.LanguageModel) {
+      if (!this._canUsePromptApiPolyfill) {
+        return false;
+      }
       await import('prompt-api-polyfill');
     }
+    return !!win.LanguageModel;
   }
 
   static availability(options = {}) {
     const p = (async () => {
       this._checkContext();
-      await this.ensureLanguageModel();
+      if (!(await this.ensureLanguageModel())) {
+        return 'unavailable';
+      }
       const lmOptions = {
         expectedInputs: [
           {

--- a/built-in-ai-task-apis-polyfills/package-lock.json
+++ b/built-in-ai-task-apis-polyfills/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "built-in-ai-task-apis-polyfills",
-  "version": "1.17.0",
+  "version": "1.18.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "built-in-ai-task-apis-polyfills",
-      "version": "1.17.0",
+      "version": "1.18.0",
       "license": "Apache-2.0",
       "dependencies": {
         "prompt-api-polyfill": "^1.20.4"

--- a/built-in-ai-task-apis-polyfills/package.json
+++ b/built-in-ai-task-apis-polyfills/package.json
@@ -1,6 +1,6 @@
 {
   "name": "built-in-ai-task-apis-polyfills",
-  "version": "1.17.0",
+  "version": "1.18.0",
   "description": "Polyfills for the Built-in AI Task APIs (Summarizer, Writer, Rewriter, etc.)",
   "type": "module",
   "main": "./dist/index.js",

--- a/built-in-ai-task-apis-polyfills/rewriter-api-polyfill.js
+++ b/built-in-ai-task-apis-polyfills/rewriter-api-polyfill.js
@@ -8,11 +8,17 @@ import { RewriterPromptBuilder } from './rewriter-prompt-builder.js';
 
 /**
  * Rewriter API Polyfill
- * Backed by Prompt API Polyfill (LanguageModel)
+ * Backed by the browser's LanguageModel API. Unlike the other Task API
+ * polyfills, it does not fall back to the Prompt API polyfill.
  */
 
 export class Rewriter extends BaseTaskModel {
   #options;
+
+  // The Rewriter API is not polyfilled on top of the Prompt API polyfill: it is
+  // only backed by a LanguageModel implementation the browser already
+  // provides.
+  static _canUsePromptApiPolyfill = false;
 
   constructor(session, builder, options) {
     super(session, builder);
@@ -61,7 +67,12 @@ export class Rewriter extends BaseTaskModel {
       expectedContextLanguages,
     };
 
-    await this.ensureLanguageModel();
+    if (!(await this.ensureLanguageModel())) {
+      throw new DOMException(
+        'The Rewriter API polyfill requires the LanguageModel API, which is not available.',
+        'NotSupportedError'
+      );
+    }
     this._checkContext();
     const builder = new RewriterPromptBuilder(validatedOptions);
     const { systemPrompt } = builder.buildPrompt('');

--- a/built-in-ai-task-apis-polyfills/writer-api-polyfill.js
+++ b/built-in-ai-task-apis-polyfills/writer-api-polyfill.js
@@ -8,11 +8,17 @@ import { WriterPromptBuilder } from './writer-prompt-builder.js';
 
 /**
  * Writer API Polyfill
- * Backed by Prompt API Polyfill (LanguageModel)
+ * Backed by the browser's LanguageModel API. Unlike the other Task API
+ * polyfills, it does not fall back to the Prompt API polyfill.
  */
 
 export class Writer extends BaseTaskModel {
   #options;
+
+  // The Writer API is not polyfilled on top of the Prompt API polyfill: it is
+  // only backed by a LanguageModel implementation the browser already
+  // provides.
+  static _canUsePromptApiPolyfill = false;
 
   constructor(session, builder, options) {
     super(session, builder);
@@ -61,7 +67,12 @@ export class Writer extends BaseTaskModel {
       expectedContextLanguages,
     };
 
-    await this.ensureLanguageModel();
+    if (!(await this.ensureLanguageModel())) {
+      throw new DOMException(
+        'The Writer API polyfill requires the LanguageModel API, which is not available.',
+        'NotSupportedError'
+      );
+    }
     this._checkContext();
     const builder = new WriterPromptBuilder(validatedOptions);
     const { systemPrompt } = builder.buildPrompt('');

--- a/built-in-ai-task-apis-polyfills/writer-rewriter-deprecation.md
+++ b/built-in-ai-task-apis-polyfills/writer-rewriter-deprecation.md
@@ -1,0 +1,150 @@
+# Deprecation of the Writer and Rewriter APIs
+
+Chrome is proposing to deprecate and remove the experimental Writer and Rewriter
+APIs. This document explains why, and how to keep the feature working in your
+app with the polyfill in this package.
+
+## Why
+
+Both APIs were explored as task-specific abstractions and reached an origin
+trial, but the signal from that trial was consistent: developers preferred to
+implement writing and rewriting directly with the Prompt API
+(`window.LanguageModel`).
+
+That preference is a reasonable one, because the two APIs were never more than
+templatized system prompts over the same on-device model the Prompt API exposes.
+Custom prompting reached the same results, or better ones, and base models have
+improved to the point where adjusting tone, length, and format needs no
+dedicated API. Retiring these thin abstractions frees up effort for task APIs
+where a dedicated model does earn its place, such as Summarizer and Translator,
+and for primitives that unlock things the platform cannot do yet, such as
+embeddings and tool calling.
+
+## What the polyfill can and cannot do for you
+
+The polyfill keeps `window.Writer` and `window.Rewriter` working by
+reimplementing them on top of `window.LanguageModel`, using the same system
+prompt templates Chrome used. Your calling code does not change.
+
+In a browser without `window.LanguageModel`, `Writer.availability()` and
+`Rewriter.availability()` resolve with `'unavailable'`, and `Writer.create()`
+and `Rewriter.create()` reject with a `NotSupportedError`.
+
+## Using it
+
+Install the package:
+
+```bash
+npm install built-in-ai-task-apis-polyfills
+```
+
+Load a polyfill only where the native API is missing, so browsers that still
+ship it keep using it:
+
+```js
+const polyfills = [];
+if (!('Writer' in self)) {
+  polyfills.push(import('built-in-ai-task-apis-polyfills/writer'));
+}
+if (!('Rewriter' in self)) {
+  polyfills.push(import('built-in-ai-task-apis-polyfills/rewriter'));
+}
+await Promise.all(polyfills);
+```
+
+Then check availability before you offer the feature. Because there is no
+fallback behind it, `'unavailable'` is the answer you should design for first:
+
+```js
+const options = { tone: 'neutral', format: 'plain-text', outputLanguage: 'en' };
+
+switch (await Writer.availability(options)) {
+  case 'unavailable':
+    // No Prompt API in this browser, so the Writer API can't work.
+    // Fall back to whatever your app did before.
+    showPlainEditor();
+    break;
+  case 'downloadable':
+  case 'downloading':
+    // The model still has to arrive. Ask first, then report progress below.
+    showDownloadPrompt();
+    break;
+  case 'available':
+    showWriterUi();
+    break;
+}
+```
+
+Creating a writer is unchanged, including the download monitor:
+
+```js
+try {
+  const writer = await Writer.create({
+    ...options,
+    sharedContext: 'An email to a colleague.',
+    monitor: (m) => {
+      m.addEventListener('downloadprogress', (e) => {
+        progress.value = e.loaded;
+        progress.max = e.total;
+      });
+    },
+  });
+  
+  const draft = await writer.write('Tell her I will be late.');
+  writer.destroy();
+} catch (error) {
+  if (error.name === 'NotSupportedError') {
+    showPlainEditor();
+  } else {
+    throw error;
+  }
+}
+```
+
+`Rewriter` works the same way, with `rewrite()` in place of `write()`.
+
+## If you _do_ want a fallback
+
+The polyfill will not reach for one on its own, but it does not stand in your
+way either. It looks for `window.LanguageModel` at the moment you call
+`availability()` or `create()`, so if you load the
+[`prompt-api-polyfill`](https://github.com/GoogleChromeLabs/web-ai-demos/tree/main/prompt-api-polyfill)
+yourself first, Writer and Rewriter will use it, and its configuration globals
+apply again:
+
+```bash
+npm install prompt-api-polyfill
+```
+
+```js
+if (!('LanguageModel' in self)) {
+  // Your choice and trade-off. Configure a backend first, for example with
+  // window.GEMINI_CONFIG or window.TRANSFORMERS_CONFIG.
+  await import('prompt-api-polyfill');
+}
+await import('built-in-ai-task-apis-polyfills/writer');
+```
+
+Make that choice deliberately. A cloud backend sends your users' text to a third
+party and needs an API key you have to keep out of your client bundle, and a
+local backend downloads a model measured in hundreds of megabytes before the
+first word is written. Neither is a drop-in replacement, which is why it is
+opt-in.
+
+## If you would rather not use the polyfill
+
+Prompt the model yourself. The system prompt templates behind these APIs are in
+[`writer-prompt-builder.js`](./writer-prompt-builder.js) and
+[`rewriter-prompt-builder.js`](./rewriter-prompt-builder.js). They are meant to
+be read, taken apart, and adapted: start from the template for the tone, format,
+and length you need, and drop the rest.
+
+## Tell us if this does not work for you
+
+The proposal is not final, and the point of announcing it early is to find the
+use cases it would break. If you have been testing these APIs and the Prompt API
+or this polyfill falls short on quality, performance, or ergonomics, describe
+the case in the
+[Writer and Rewriter APIs consultation form](https://docs.google.com/forms/d/e/1FAIpQLSeyCU1PmpB6t5JtNN0qR1xDVB2iPOKxZ9Tjh4bQwOKz5JsBJw/viewform).
+Concrete examples carry the most weight, and we will follow up with a short
+technical conversation where one would help.

--- a/built-in-ai-task-apis-polyfills/writer-rewriter-deprecation.md
+++ b/built-in-ai-task-apis-polyfills/writer-rewriter-deprecation.md
@@ -103,34 +103,6 @@ try {
 
 `Rewriter` works the same way, with `rewrite()` in place of `write()`.
 
-## If you _do_ want a fallback
-
-The polyfill will not reach for one on its own, but it does not stand in your
-way either. It looks for `window.LanguageModel` at the moment you call
-`availability()` or `create()`, so if you load the
-[`prompt-api-polyfill`](https://github.com/GoogleChromeLabs/web-ai-demos/tree/main/prompt-api-polyfill)
-yourself first, Writer and Rewriter will use it, and its configuration globals
-apply again:
-
-```bash
-npm install prompt-api-polyfill
-```
-
-```js
-if (!('LanguageModel' in self)) {
-  // Your choice and trade-off. Configure a backend first, for example with
-  // window.GEMINI_CONFIG or window.TRANSFORMERS_CONFIG.
-  await import('prompt-api-polyfill');
-}
-await import('built-in-ai-task-apis-polyfills/writer');
-```
-
-Make that choice deliberately. A cloud backend sends your users' text to a third
-party and needs an API key you have to keep out of your client bundle, and a
-local backend downloads a model measured in hundreds of megabytes before the
-first word is written. Neither is a drop-in replacement, which is why it is
-opt-in.
-
 ## If you would rather not use the polyfill
 
 Prompt the model yourself. The system prompt templates behind these APIs are in


### PR DESCRIPTION
The Writer and Rewriter polyfills no longer load `prompt-api-polyfill` when `window.LanguageModel` is missing. They now only run on a LanguageModel implementation the browser already provides:

- `Writer.availability()` / `Rewriter.availability()` resolve with `'unavailable'`.
- `Writer.create()` / `Rewriter.create()` reject with a `NotSupportedError`.

Every other Task API polyfill (Summarizer, Language Detector, Translator, Classifier) keeps the fallback. `BaseTaskModel.ensureLanguageModel()` now reports whether a LanguageModel is available instead of returning `undefined`, and skips the dynamic import only for classes that opt out through the new `_canUsePromptApiPolyfill` static.

README updated to describe the split, and the package version bumped to 1.18.0.
