### PR TITLE
Align the polyfills prettier config with my global default

### DIFF
--- a/built-in-ai-task-apis-polyfills/.prettierrc
+++ b/built-in-ai-task-apis-polyfills/.prettierrc
@@ -1,6 +1,7 @@
 {
   "arrowParens": "always",
   "bracketSpacing": true,
+  "embeddedLanguageFormatting": "auto",
   "htmlWhitespaceSensitivity": "css",
   "insertPragma": false,
   "bracketSameLine": false,
@@ -11,8 +12,16 @@
   "requirePragma": false,
   "semi": true,
   "singleQuote": true,
+  "overrides": [
+    {
+      "files": ["**/*.css", "**/*.scss"],
+      "options": {
+        "singleQuote": false
+      }
+    }
+  ],
   "tabWidth": 2,
-  "trailingComma": "es5",
+  "trailingComma": "all",
   "useTabs": false,
   "vueIndentScriptAndStyle": false,
   "plugins": ["prettier-plugin-curly"]

--- a/built-in-ai-task-apis-polyfills/README.md
+++ b/built-in-ai-task-apis-polyfills/README.md
@@ -126,7 +126,7 @@ const writer = await Writer.create({
 });
 
 const result = await writer.write(
-  'Draft of an email to my boss telling her I will be late.'
+  'Draft of an email to my boss telling her I will be late.',
 );
 ```
 
@@ -138,7 +138,7 @@ const rewriter = await Rewriter.create({
 });
 
 const result = await rewriter.rewrite(
-  'I am writing to inform you that I will be late.'
+  'I am writing to inform you that I will be late.',
 );
 ```
 
@@ -224,7 +224,7 @@ function cosineSimilarity(a, b) {
 }
 
 const scores = docsResult.embeddings.map((e) =>
-  cosineSimilarity(queryVec, e.values)
+  cosineSimilarity(queryVec, e.values),
 );
 ```
 

--- a/built-in-ai-task-apis-polyfills/base-task-model.js
+++ b/built-in-ai-task-apis-polyfills/base-task-model.js
@@ -146,7 +146,7 @@ export class BaseTaskModel {
     if (this.#destroyed) {
       const p = Promise.reject(
         this.#destructionReason ||
-          new DOMException('The summarizer has been destroyed.', 'AbortError')
+          new DOMException('The summarizer has been destroyed.', 'AbortError'),
       );
       p.catch(() => {});
       return p;
@@ -154,12 +154,12 @@ export class BaseTaskModel {
     const { userPrompt } = this.#builder.buildPrompt(input, options);
 
     const combinedSignal = AbortSignal.any(
-      [this.#destructionController.signal, options.signal].filter(Boolean)
+      [this.#destructionController.signal, options.signal].filter(Boolean),
     );
 
     if (combinedSignal.aborted) {
       const p = Promise.reject(
-        combinedSignal.reason || new DOMException('Aborted', 'AbortError')
+        combinedSignal.reason || new DOMException('Aborted', 'AbortError'),
       );
       p.catch(() => {});
       return p;
@@ -173,7 +173,7 @@ export class BaseTaskModel {
       return await new Promise((resolve, reject) => {
         const onAbort = () => {
           reject(
-            combinedSignal.reason || new DOMException('Aborted', 'AbortError')
+            combinedSignal.reason || new DOMException('Aborted', 'AbortError'),
           );
         };
         if (combinedSignal.aborted) {
@@ -218,7 +218,7 @@ export class BaseTaskModel {
 
     const _this = this;
     const combinedSignal = AbortSignal.any(
-      [this.#destructionController.signal, options.signal].filter(Boolean)
+      [this.#destructionController.signal, options.signal].filter(Boolean),
     );
 
     if (combinedSignal.aborted) {
@@ -232,8 +232,8 @@ export class BaseTaskModel {
             _this.#destructionReason ||
               new DOMException(
                 'The summarizer has been destroyed.',
-                'AbortError'
-              )
+                'AbortError',
+              ),
           );
           return;
         }
@@ -258,7 +258,8 @@ export class BaseTaskModel {
           }
           try {
             controller.error(
-              combinedSignal.reason || new DOMException('Aborted', 'AbortError')
+              combinedSignal.reason ||
+                new DOMException('Aborted', 'AbortError'),
             );
           } catch {
             // Ignore if already closed/errored
@@ -279,7 +280,7 @@ export class BaseTaskModel {
 
           const stream = clonedSession.promptStreaming(
             userPrompt,
-            mergedOptions
+            mergedOptions,
           );
           reader = stream.getReader();
           while (true) {
@@ -305,19 +306,19 @@ export class BaseTaskModel {
     if (this.#destroyed) {
       const p = Promise.reject(
         this.#destructionReason ||
-          new DOMException('The summarizer has been destroyed.', 'AbortError')
+          new DOMException('The summarizer has been destroyed.', 'AbortError'),
       );
       p.catch(() => {});
       return p;
     }
 
     const combinedSignal = AbortSignal.any(
-      [this.#destructionController.signal, options.signal].filter(Boolean)
+      [this.#destructionController.signal, options.signal].filter(Boolean),
     );
 
     if (combinedSignal.aborted) {
       const p = Promise.reject(
-        combinedSignal.reason || new DOMException('Aborted', 'AbortError')
+        combinedSignal.reason || new DOMException('Aborted', 'AbortError'),
       );
       p.catch(() => {});
       return p;
@@ -326,7 +327,7 @@ export class BaseTaskModel {
     const p = new Promise((resolve, reject) => {
       const onAbort = () =>
         reject(
-          combinedSignal.reason || new DOMException('Aborted', 'AbortError')
+          combinedSignal.reason || new DOMException('Aborted', 'AbortError'),
         );
 
       combinedSignal.addEventListener('abort', onAbort, {
@@ -428,7 +429,7 @@ export class BaseTaskModel {
       try {
         const descriptor = Object.getOwnPropertyDescriptor(
           HTMLIFrameElement.prototype,
-          'contentWindow'
+          'contentWindow',
         );
         if (descriptor && descriptor.get) {
           Object.defineProperty(HTMLIFrameElement.prototype, 'contentWindow', {
@@ -475,7 +476,7 @@ export class BaseTaskModel {
 
     if (globalThis[apiName] && globalThis[apiName].__isPolyfill) {
       console.log(
-        `Polyfill: window.${apiName} is now backed by the ${apiName} API polyfill.`
+        `Polyfill: window.${apiName} is now backed by the ${apiName} API polyfill.`,
       );
     }
   }

--- a/built-in-ai-task-apis-polyfills/classifier-api-polyfill.js
+++ b/built-in-ai-task-apis-polyfills/classifier-api-polyfill.js
@@ -49,7 +49,7 @@ export class Classifier extends BaseTaskModel {
         () => {
           classifier.destroy(options.signal.reason);
         },
-        { once: true }
+        { once: true },
       );
     }
 
@@ -146,5 +146,5 @@ export class Classifier extends BaseTaskModel {
 BaseTaskModel.exposeAPIGlobally(
   'Classifier',
   Classifier,
-  '__FORCE_CLASSIFIER_POLYFILL__'
+  '__FORCE_CLASSIFIER_POLYFILL__',
 );

--- a/built-in-ai-task-apis-polyfills/classifier-prompt-builder.js
+++ b/built-in-ai-task-apis-polyfills/classifier-prompt-builder.js
@@ -762,7 +762,7 @@ JSON Schema for output:
         ClassifierPromptBuilder.#systemPromptTemplate,
         '{{taxonomy}}',
         taxonomyList,
-        'taxonomy'
+        'taxonomy',
       ),
       initialPrompts: [
         {

--- a/built-in-ai-task-apis-polyfills/demo-classifier.html
+++ b/built-in-ai-task-apis-polyfills/demo-classifier.html
@@ -135,7 +135,7 @@ The new experimental fusion reactor at the ITER site in France has successfully 
         firebaseConfig = await response.json();
       } catch (e) {
         console.warn(
-          'Firebase config (.env.json) not found, relying on local LanguageModel if available.'
+          'Firebase config (.env.json) not found, relying on local LanguageModel if available.',
         );
       }
       window.FIREBASE_CONFIG = firebaseConfig;

--- a/built-in-ai-task-apis-polyfills/demo-language-detector.html
+++ b/built-in-ai-task-apis-polyfills/demo-language-detector.html
@@ -93,7 +93,7 @@ The web is a vast place. Built-in AI APIs like the Language Detector API allow d
         firebaseConfig = await response.json();
       } catch (e) {
         console.warn(
-          'Firebase config (.env.json) not found, relying on local LanguageDetector if available.'
+          'Firebase config (.env.json) not found, relying on local LanguageDetector if available.',
         );
       }
       window.FIREBASE_CONFIG = firebaseConfig;

--- a/built-in-ai-task-apis-polyfills/demo-rewriter.html
+++ b/built-in-ai-task-apis-polyfills/demo-rewriter.html
@@ -184,7 +184,7 @@ The Rewriter API provides a way to rewrite text while controlling the tone, form
         firebaseConfig = await response.json();
       } catch (e) {
         console.warn(
-          'Firebase config (.env.json) not found, relying on local Rewriter if available.'
+          'Firebase config (.env.json) not found, relying on local Rewriter if available.',
         );
       }
       window.FIREBASE_CONFIG = firebaseConfig;
@@ -196,10 +196,10 @@ The Rewriter API provides a way to rewrite text while controlling the tone, form
       const format = document.getElementById('format');
       const length = document.getElementById('length');
       const expectedInputLanguages = document.getElementById(
-        'expectedInputLanguages'
+        'expectedInputLanguages',
       );
       const expectedContextLanguages = document.getElementById(
-        'expectedContextLanguages'
+        'expectedContextLanguages',
       );
       const outputLanguage = document.getElementById('outputLanguage');
       const rewriteBtn = document.getElementById('rewriteBtn');

--- a/built-in-ai-task-apis-polyfills/demo-summarizer.html
+++ b/built-in-ai-task-apis-polyfills/demo-summarizer.html
@@ -144,7 +144,7 @@ The web is a vast place. Built-in AI APIs like the Summarizer API allow develope
         firebaseConfig = await response.json();
       } catch (e) {
         console.warn(
-          'Firebase config (.env.json) not found, relying on local Summarizer if available.'
+          'Firebase config (.env.json) not found, relying on local Summarizer if available.',
         );
       }
       window.FIREBASE_CONFIG = firebaseConfig;
@@ -159,10 +159,10 @@ The web is a vast place. Built-in AI APIs like the Summarizer API allow develope
       const format = document.getElementById('format');
       const length = document.getElementById('length');
       const expectedInputLanguages = document.getElementById(
-        'expectedInputLanguages'
+        'expectedInputLanguages',
       );
       const expectedContextLanguages = document.getElementById(
-        'expectedContextLanguages'
+        'expectedContextLanguages',
       );
       const outputLanguage = document.getElementById('outputLanguage');
       const summarizeBtn = document.getElementById('summarizeBtn');

--- a/built-in-ai-task-apis-polyfills/demo-translator.html
+++ b/built-in-ai-task-apis-polyfills/demo-translator.html
@@ -121,7 +121,7 @@ Hello, how are you today? I hope you are having a wonderful time.</textarea
         firebaseConfig = await response.json();
       } catch (e) {
         console.warn(
-          'Firebase config (.env.json) not found, relying on local Translator if available.'
+          'Firebase config (.env.json) not found, relying on local Translator if available.',
         );
       }
       window.FIREBASE_CONFIG = firebaseConfig;
@@ -133,7 +133,7 @@ Hello, how are you today? I hope you are having a wonderful time.</textarea
       const targetLanguage = document.getElementById('targetLanguage');
       const translateBtn = document.getElementById('translateBtn');
       const translateStreamingBtn = document.getElementById(
-        'translateStreamingBtn'
+        'translateStreamingBtn',
       );
       const stopBtn = document.getElementById('stopBtn');
       const output = document.getElementById('output');
@@ -179,7 +179,7 @@ Hello, how are you today? I hope you are having a wonderful time.</textarea
               progress.value = e.loaded;
               progress.max = e.total;
               setStatus(
-                `Downloading model: ${Math.round((e.loaded / e.total) * 100)}%`
+                `Downloading model: ${Math.round((e.loaded / e.total) * 100)}%`,
               );
               if (e.loaded === e.total) {
                 setStatus('Model loaded.');

--- a/built-in-ai-task-apis-polyfills/demo-writer.html
+++ b/built-in-ai-task-apis-polyfills/demo-writer.html
@@ -183,7 +183,7 @@ The history of artificial intelligence started with Alan Turing's work...</texta
         firebaseConfig = await response.json();
       } catch (e) {
         console.warn(
-          'Firebase config (.env.json) not found, relying on local Writer if available.'
+          'Firebase config (.env.json) not found, relying on local Writer if available.',
         );
       }
       window.FIREBASE_CONFIG = firebaseConfig;
@@ -195,10 +195,10 @@ The history of artificial intelligence started with Alan Turing's work...</texta
       const format = document.getElementById('format');
       const length = document.getElementById('length');
       const expectedInputLanguages = document.getElementById(
-        'expectedInputLanguages'
+        'expectedInputLanguages',
       );
       const expectedContextLanguages = document.getElementById(
-        'expectedContextLanguages'
+        'expectedContextLanguages',
       );
       const outputLanguage = document.getElementById('outputLanguage');
       const writeBtn = document.getElementById('writeBtn');

--- a/built-in-ai-task-apis-polyfills/language-detector-api-polyfill.js
+++ b/built-in-ai-task-apis-polyfills/language-detector-api-polyfill.js
@@ -32,7 +32,7 @@ class LanguageDetectorPromptBuilder {
           },
         ],
         null,
-        2
+        2,
       ),
     },
     {
@@ -53,7 +53,7 @@ class LanguageDetectorPromptBuilder {
           },
         ],
         null,
-        2
+        2,
       ),
     },
     {
@@ -74,7 +74,7 @@ class LanguageDetectorPromptBuilder {
           },
         ],
         null,
-        2
+        2,
       ),
     },
     {
@@ -95,7 +95,7 @@ class LanguageDetectorPromptBuilder {
           },
         ],
         null,
-        2
+        2,
       ),
     },
     {
@@ -116,7 +116,7 @@ class LanguageDetectorPromptBuilder {
           },
         ],
         null,
-        2
+        2,
       ),
     },
     {
@@ -137,7 +137,7 @@ class LanguageDetectorPromptBuilder {
           },
         ],
         null,
-        2
+        2,
       ),
     },
     {
@@ -158,7 +158,7 @@ class LanguageDetectorPromptBuilder {
           },
         ],
         null,
-        2
+        2,
       ),
     },
   ];
@@ -198,8 +198,8 @@ export class LanguageDetector extends BaseTaskModel {
       ? [
           ...new Set(
             options.expectedInputLanguages.map((tag) =>
-              this._validateLanguageTag(tag)
-            )
+              this._validateLanguageTag(tag),
+            ),
           ),
         ]
       : null;
@@ -242,7 +242,7 @@ export class LanguageDetector extends BaseTaskModel {
         () => {
           detector.destroy(options.signal.reason);
         },
-        { once: true }
+        { once: true },
       );
     }
 
@@ -346,5 +346,5 @@ export class LanguageDetector extends BaseTaskModel {
 BaseTaskModel.exposeAPIGlobally(
   'LanguageDetector',
   LanguageDetector,
-  '__FORCE_LANGUAGE_DETECTOR_POLYFILL__'
+  '__FORCE_LANGUAGE_DETECTOR_POLYFILL__',
 );

--- a/built-in-ai-task-apis-polyfills/rewriter-api-polyfill.js
+++ b/built-in-ai-task-apis-polyfills/rewriter-api-polyfill.js
@@ -45,12 +45,12 @@ export class Rewriter extends BaseTaskModel {
       : null;
     const expectedInputLanguages = options.expectedInputLanguages
       ? options.expectedInputLanguages.map((tag) =>
-          this._validateLanguageTag(tag)
+          this._validateLanguageTag(tag),
         )
       : null;
     const expectedContextLanguages = options.expectedContextLanguages
       ? options.expectedContextLanguages.map((tag) =>
-          this._validateLanguageTag(tag)
+          this._validateLanguageTag(tag),
         )
       : null;
 
@@ -82,7 +82,7 @@ export class Rewriter extends BaseTaskModel {
         () => {
           rewriter.destroy(options.signal.reason);
         },
-        { once: true }
+        { once: true },
       );
     }
 
@@ -136,5 +136,5 @@ export class Rewriter extends BaseTaskModel {
 BaseTaskModel.exposeAPIGlobally(
   'Rewriter',
   Rewriter,
-  '__FORCE_REWRITER_POLYFILL__'
+  '__FORCE_REWRITER_POLYFILL__',
 );

--- a/built-in-ai-task-apis-polyfills/rewriter-prompt-builder.js
+++ b/built-in-ai-task-apis-polyfills/rewriter-prompt-builder.js
@@ -109,7 +109,7 @@ export class RewriterPromptBuilder {
       systemPrompt,
       /\*\*(Japanese|English)\*\*/g,
       `**${this.getLanguageName(outputLanguage)}**`,
-      'language'
+      'language',
     );
 
     // 3. Parametrize Context Instructions
@@ -122,7 +122,7 @@ export class RewriterPromptBuilder {
         systemPrompt,
         contextInstruction,
         '',
-        'context instruction'
+        'context instruction',
       );
     }
 

--- a/built-in-ai-task-apis-polyfills/scripts/classifier-taxonomy-extractor.js
+++ b/built-in-ai-task-apis-polyfills/scripts/classifier-taxonomy-extractor.js
@@ -54,11 +54,11 @@ function updateBuilder(taxonomyData) {
     if (regex.test(content)) {
       content = content.replace(
         regex,
-        `${startMarker}\n  ${newData}\n  ${endMarker}`
+        `${startMarker}\n  ${newData}\n  ${endMarker}`,
       );
     } else {
       throw new Error(
-        'Could not find #taxonomyData in classifier-prompt-builder.js'
+        'Could not find #taxonomyData in classifier-prompt-builder.js',
       );
     }
   } else {
@@ -71,7 +71,7 @@ function updateBuilder(taxonomyData) {
 
   fs.writeFileSync(OUTPUT_FILE, content);
   console.log(
-    'Successfully updated classifier-prompt-builder.js with the latest taxonomy data.'
+    'Successfully updated classifier-prompt-builder.js with the latest taxonomy data.',
   );
 }
 

--- a/built-in-ai-task-apis-polyfills/scripts/generate-wpt-wrappers.js
+++ b/built-in-ai-task-apis-polyfills/scripts/generate-wpt-wrappers.js
@@ -13,7 +13,7 @@ const WPT_DIR = path.join(ROOT_DIR, 'tests', 'wpt');
 const PROMPT_API_POLYFILL_DIR = path.resolve(
   ROOT_DIR,
   '..',
-  'prompt-api-polyfill'
+  'prompt-api-polyfill',
 );
 
 // Configuration scanning from prompt-api-polyfill
@@ -23,7 +23,7 @@ const backendFiles = fs.existsSync(backendsDir)
       .readdirSync(backendsDir)
       .filter(
         (file) =>
-          file.endsWith('.js') && file !== 'base.js' && file !== 'defaults.js'
+          file.endsWith('.js') && file !== 'base.js' && file !== 'defaults.js',
       )
   : [];
 
@@ -42,7 +42,7 @@ const backendConfigs = {};
 const localEnvFile = path.join(ROOT_DIR, '.env.json');
 if (fs.existsSync(localEnvFile)) {
   backendConfigs['FIREBASE_CONFIG'] = JSON.parse(
-    fs.readFileSync(localEnvFile, 'utf8')
+    fs.readFileSync(localEnvFile, 'utf8'),
   );
 }
 
@@ -345,7 +345,7 @@ for (const api of apis) {
 
   // Generate index.html with matrix
   const backendNames = activeBackends.map((k) =>
-    k.replace('_CONFIG', '').toLowerCase()
+    k.replace('_CONFIG', '').toLowerCase(),
   );
   const apiIndexHtml = `<!DOCTYPE html>
 <html lang="en">
@@ -401,7 +401,7 @@ for (const api of apis) {
                       })
                       .join('')}
                 </tr>
-            `
+            `,
               )
               .join('')}
         </tbody>
@@ -439,7 +439,7 @@ const rootIndexHtml = `<!DOCTYPE html>
                 <a href="${api}/index.html"><strong>${api.toUpperCase()}</strong></a>
                 (${apiTests[api].length} tests × ${activeBackends.length} backends)
             </li>
-        `
+        `,
           )
           .join('')}
     </ul>

--- a/built-in-ai-task-apis-polyfills/scripts/rewriter-prompt-extractor.js
+++ b/built-in-ai-task-apis-polyfills/scripts/rewriter-prompt-extractor.js
@@ -25,7 +25,7 @@ const RewriterPromptManager = {
         this.lengths.forEach((length) => {
           const opts = `{ tone: "${tone}", format: "${format}", length: "${length}", outputLanguage: "ja", sharedContext: 'SHARED_CONTEXT' }`;
           lines.push(
-            `await (await Rewriter.create(${opts})).rewrite('INPUT_TEXT', { context: 'INPUT_CONTEXT' });`
+            `await (await Rewriter.create(${opts})).rewrite('INPUT_TEXT', { context: 'INPUT_CONTEXT' });`,
           );
         });
       });
@@ -60,7 +60,7 @@ async function run() {
   copyToClipboard(snippet);
 
   console.log(
-    '\n1. Test snippets copied to clipboard. Paste them in chrome://on-device-internals console.'
+    '\n1. Test snippets copied to clipboard. Paste them in chrome://on-device-internals console.',
   );
   console.log("2. Click 'Dump' to download the log file.");
 
@@ -91,7 +91,7 @@ async function run() {
     copyToClipboard(finalCode);
 
     console.log(
-      '\n\x1b[32m✔ Success! Builder saved to rewriter-prompt-builder.js\x1b[0m'
+      '\n\x1b[32m✔ Success! Builder saved to rewriter-prompt-builder.js\x1b[0m',
     );
     console.log('✔ Final code also copied to your clipboard.');
   } catch (e) {

--- a/built-in-ai-task-apis-polyfills/scripts/summarizer-prompt-extractor.js
+++ b/built-in-ai-task-apis-polyfills/scripts/summarizer-prompt-extractor.js
@@ -25,7 +25,7 @@ const PromptManager = {
         this.lengths.forEach((length) => {
           const opts = `{ type: "${type}", format: "${format}", length: "${length}", outputLanguage: "ja", sharedContext: 'SHARED_CONTEXT' }`;
           lines.push(
-            `await (await Summarizer.create(${opts})).summarize('INPUT_TEXT', { context: 'INPUT_CONTEXT' });`
+            `await (await Summarizer.create(${opts})).summarize('INPUT_TEXT', { context: 'INPUT_CONTEXT' });`,
           );
         });
       });
@@ -56,14 +56,14 @@ const PromptManager = {
 async function run() {
   console.log(
     '\x1b[36m%s\x1b[0m',
-    '--- Summarizer Prompt Builder Generator ---'
+    '--- Summarizer Prompt Builder Generator ---',
   );
 
   const snippet = PromptManager.generateChromeSnippet();
   copyToClipboard(snippet);
 
   console.log(
-    '\n1. Test snippets copied to clipboard. Paste them in chrome://on-device-internals console.'
+    '\n1. Test snippets copied to clipboard. Paste them in chrome://on-device-internals console.',
   );
   console.log("2. Click 'Dump' to download the log file.");
 
@@ -94,7 +94,7 @@ async function run() {
     copyToClipboard(finalCode);
 
     console.log(
-      '\n\x1b[32m✔ Success! Builder saved to summarizer-prompt-builder.js\x1b[0m'
+      '\n\x1b[32m✔ Success! Builder saved to summarizer-prompt-builder.js\x1b[0m',
     );
     console.log('✔ Final code also copied to your clipboard.');
   } catch (e) {

--- a/built-in-ai-task-apis-polyfills/scripts/sync-wpt.js
+++ b/built-in-ai-task-apis-polyfills/scripts/sync-wpt.js
@@ -134,12 +134,12 @@ async function main() {
 
     // Filter for test files we want to load in index.html
     const testFiles = allFiles.filter(
-      (f) => f.endsWith('.js') && !f.includes('resources/')
+      (f) => f.endsWith('.js') && !f.includes('resources/'),
     );
 
     fs.writeFileSync(
       path.join(WPT_BASE_DIR, 'tests.json'),
-      JSON.stringify(testFiles, null, 2)
+      JSON.stringify(testFiles, null, 2),
     );
 
     console.log('Successfully synchronized WPT tests.');

--- a/built-in-ai-task-apis-polyfills/scripts/writer-prompt-extractor.js
+++ b/built-in-ai-task-apis-polyfills/scripts/writer-prompt-extractor.js
@@ -25,7 +25,7 @@ const WriterPromptManager = {
         this.lengths.forEach((length) => {
           const opts = `{ tone: "${tone}", format: "${format}", length: "${length}", outputLanguage: "ja", sharedContext: 'SHARED_CONTEXT' }`;
           lines.push(
-            `await (await Writer.create(${opts})).write('INPUT_TEXT', { context: 'INPUT_CONTEXT' });`
+            `await (await Writer.create(${opts})).write('INPUT_TEXT', { context: 'INPUT_CONTEXT' });`,
           );
         });
       });
@@ -60,7 +60,7 @@ async function run() {
   copyToClipboard(snippet);
 
   console.log(
-    '\n1. Test snippets copied to clipboard. Paste them in chrome://on-device-internals console.'
+    '\n1. Test snippets copied to clipboard. Paste them in chrome://on-device-internals console.',
   );
   console.log("2. Click 'Dump' to download the log file.");
 
@@ -91,7 +91,7 @@ async function run() {
     copyToClipboard(finalCode);
 
     console.log(
-      '\n\x1b[32m✔ Success! Builder saved to writer-prompt-builder.js\x1b[0m'
+      '\n\x1b[32m✔ Success! Builder saved to writer-prompt-builder.js\x1b[0m',
     );
     console.log('✔ Final code also copied to your clipboard.');
   } catch (e) {

--- a/built-in-ai-task-apis-polyfills/semantic-embedder-api-polyfill.js
+++ b/built-in-ai-task-apis-polyfills/semantic-embedder-api-polyfill.js
@@ -77,7 +77,7 @@ async function isModelCached(modelId, dtype) {
     // generation_config.json is an optional text-generation config that the
     // transformers.js cache doesn't always persist; exclude it from the check.
     const essential = result.files.filter(
-      (f) => f.file !== 'generation_config.json'
+      (f) => f.file !== 'generation_config.json',
     );
     return essential.length > 0 && essential.every((f) => f.cached);
   } catch {
@@ -213,7 +213,7 @@ if (isWorker) {
         }
 
         const prefixedInputs = inputs.map((text) =>
-          applyPrefix(text, options.taskType)
+          applyPrefix(text, options.taskType),
         );
 
         // Measure each input on its own first, so the reported token count is
@@ -221,7 +221,7 @@ if (isWorker) {
         // batch. Counting the batch in one pass is not an option: padding it
         // to an over-long member throws inside the tokenizer.
         const tokenCounts = prefixedInputs.map((text) =>
-          workerTokenizer(text).input_ids.dims.at(-1)
+          workerTokenizer(text).input_ids.dims.at(-1),
         );
 
         const tokenized = await workerTokenizer(prefixedInputs, {
@@ -404,7 +404,7 @@ export class SemanticEmbedder {
             loaded,
             total: 1,
             lengthComputable: true,
-          })
+          }),
         );
       };
     }
@@ -496,7 +496,7 @@ export class SemanticEmbedder {
         () => {
           embedder.destroy(options.signal.reason);
         },
-        { once: true }
+        { once: true },
       );
     }
 
@@ -507,7 +507,7 @@ export class SemanticEmbedder {
     if (this.#destroyed) {
       const p = Promise.reject(
         this.#destructionReason ||
-          new DOMException('The embedder has been destroyed.', 'AbortError')
+          new DOMException('The embedder has been destroyed.', 'AbortError'),
       );
       p.catch(() => {});
       return p;
@@ -530,7 +530,7 @@ export class SemanticEmbedder {
       !VALID_TASK_TYPES.has(options.taskType)
     ) {
       throw new TypeError(
-        `Failed to execute 'embed': The provided value '${options.taskType}' is not a valid enum value of type EmbedderTaskType.`
+        `Failed to execute 'embed': The provided value '${options.taskType}' is not a valid enum value of type EmbedderTaskType.`,
       );
     }
 
@@ -648,7 +648,7 @@ if (typeof globalThis !== 'undefined' && globalThis.document) {
     try {
       const descriptor = Object.getOwnPropertyDescriptor(
         HTMLIFrameElement.prototype,
-        'contentWindow'
+        'contentWindow',
       );
       if (descriptor?.get) {
         Object.defineProperty(HTMLIFrameElement.prototype, 'contentWindow', {
@@ -695,7 +695,7 @@ if (typeof globalThis !== 'undefined' && globalThis.document) {
 
   if (globalThis[apiName]?.__isPolyfill) {
     console.log(
-      `Polyfill: window.${apiName} is now backed by the ${apiName} API polyfill.`
+      `Polyfill: window.${apiName} is now backed by the ${apiName} API polyfill.`,
     );
   }
 }

--- a/built-in-ai-task-apis-polyfills/summarizer-api-polyfill.js
+++ b/built-in-ai-task-apis-polyfills/summarizer-api-polyfill.js
@@ -45,12 +45,12 @@ export class Summarizer extends BaseTaskModel {
       : null;
     const expectedInputLanguages = options.expectedInputLanguages
       ? options.expectedInputLanguages.map((tag) =>
-          this._validateLanguageTag(tag)
+          this._validateLanguageTag(tag),
         )
       : null;
     const expectedContextLanguages = options.expectedContextLanguages
       ? options.expectedContextLanguages.map((tag) =>
-          this._validateLanguageTag(tag)
+          this._validateLanguageTag(tag),
         )
       : null;
 
@@ -82,7 +82,7 @@ export class Summarizer extends BaseTaskModel {
         () => {
           summarizer.destroy(options.signal.reason);
         },
-        { once: true }
+        { once: true },
       );
     }
 
@@ -136,5 +136,5 @@ export class Summarizer extends BaseTaskModel {
 BaseTaskModel.exposeAPIGlobally(
   'Summarizer',
   Summarizer,
-  '__FORCE_SUMMARIZER_POLYFILL__'
+  '__FORCE_SUMMARIZER_POLYFILL__',
 );

--- a/built-in-ai-task-apis-polyfills/summarizer-prompt-builder.js
+++ b/built-in-ai-task-apis-polyfills/summarizer-prompt-builder.js
@@ -104,7 +104,7 @@ export class SummarizerPromptBuilder {
       systemPrompt,
       /The (summary|teaser|bullet points|headline) must be written in (Japanese|English)\./,
       `The $1 must be written in ${this.getLanguageName(outputLanguage)}.`,
-      'language'
+      'language',
     );
 
     // 3. Parametrize Context Instructions
@@ -115,13 +115,13 @@ export class SummarizerPromptBuilder {
     if (!hasContext) {
       const escapedInstr = contextInstruction.replace(
         /[.*+?^\${}()|[\]\\]/g,
-        '\\$&'
+        '\\$&',
       );
       systemPrompt = replaceOrThrow(
         systemPrompt,
         new RegExp(`\\n?${escapedInstr}`),
         '',
-        'context instruction'
+        'context instruction',
       );
     }
 

--- a/built-in-ai-task-apis-polyfills/translator-api-polyfill.js
+++ b/built-in-ai-task-apis-polyfills/translator-api-polyfill.js
@@ -33,7 +33,7 @@ export class Translator extends BaseTaskModel {
   static create(options) {
     if (!options || !options.sourceLanguage || !options.targetLanguage) {
       return Promise.reject(
-        new TypeError('sourceLanguage and targetLanguage are required')
+        new TypeError('sourceLanguage and targetLanguage are required'),
       );
     }
     const p = this._createInternal(options);
@@ -67,7 +67,7 @@ export class Translator extends BaseTaskModel {
       session,
       builder,
       sourceLanguage,
-      targetLanguage
+      targetLanguage,
     );
 
     if (options.signal) {
@@ -76,7 +76,7 @@ export class Translator extends BaseTaskModel {
         () => {
           translator.destroy(options.signal.reason);
         },
-        { once: true }
+        { once: true },
       );
     }
 
@@ -114,5 +114,5 @@ export class Translator extends BaseTaskModel {
 BaseTaskModel.exposeAPIGlobally(
   'Translator',
   Translator,
-  '__FORCE_TRANSLATOR_POLYFILL__'
+  '__FORCE_TRANSLATOR_POLYFILL__',
 );

--- a/built-in-ai-task-apis-polyfills/vite.config.js
+++ b/built-in-ai-task-apis-polyfills/vite.config.js
@@ -25,13 +25,13 @@ export default defineConfig({
         rewriter: resolve(__dirname, 'rewriter-api-polyfill.js'),
         'language-detector': resolve(
           __dirname,
-          'language-detector-api-polyfill.js'
+          'language-detector-api-polyfill.js',
         ),
         translator: resolve(__dirname, 'translator-api-polyfill.js'),
         classifier: resolve(__dirname, 'classifier-api-polyfill.js'),
         'semantic-embedder': resolve(
           __dirname,
-          'semantic-embedder-api-polyfill.js'
+          'semantic-embedder-api-polyfill.js',
         ),
       },
       formats: ['es'],

--- a/built-in-ai-task-apis-polyfills/vite.demos.config.js
+++ b/built-in-ai-task-apis-polyfills/vite.demos.config.js
@@ -28,15 +28,9 @@ export default defineConfig({
       input: {
         index: resolve(__dirname, 'index.html'),
         classifier: resolve(__dirname, 'demo-classifier.html'),
-        'language-detector': resolve(
-          __dirname,
-          'demo-language-detector.html'
-        ),
+        'language-detector': resolve(__dirname, 'demo-language-detector.html'),
         rewriter: resolve(__dirname, 'demo-rewriter.html'),
-        'semantic-embedder': resolve(
-          __dirname,
-          'demo-semantic-embedder.html'
-        ),
+        'semantic-embedder': resolve(__dirname, 'demo-semantic-embedder.html'),
         summarizer: resolve(__dirname, 'demo-summarizer.html'),
         translator: resolve(__dirname, 'demo-translator.html'),
         writer: resolve(__dirname, 'demo-writer.html'),

--- a/built-in-ai-task-apis-polyfills/writer-api-polyfill.js
+++ b/built-in-ai-task-apis-polyfills/writer-api-polyfill.js
@@ -45,12 +45,12 @@ export class Writer extends BaseTaskModel {
       : null;
     const expectedInputLanguages = options.expectedInputLanguages
       ? options.expectedInputLanguages.map((tag) =>
-          this._validateLanguageTag(tag)
+          this._validateLanguageTag(tag),
         )
       : null;
     const expectedContextLanguages = options.expectedContextLanguages
       ? options.expectedContextLanguages.map((tag) =>
-          this._validateLanguageTag(tag)
+          this._validateLanguageTag(tag),
         )
       : null;
 
@@ -82,7 +82,7 @@ export class Writer extends BaseTaskModel {
         () => {
           writer.destroy(options.signal.reason);
         },
-        { once: true }
+        { once: true },
       );
     }
 

--- a/built-in-ai-task-apis-polyfills/writer-prompt-builder.js
+++ b/built-in-ai-task-apis-polyfills/writer-prompt-builder.js
@@ -92,7 +92,7 @@ export class WriterPromptBuilder {
       systemPrompt,
       /You MUST write exclusively and entirely in (Japanese|English)\./,
       `You MUST write exclusively and entirely in ${this.getLanguageName(outputLanguage)}.`,
-      'language'
+      'language',
     );
 
     // 3. Parametrize Context Instructions
@@ -105,7 +105,7 @@ export class WriterPromptBuilder {
         systemPrompt,
         contextInstruction,
         '',
-        'context instruction'
+        'context instruction',
       );
     }
 


### PR DESCRIPTION
`built-in-ai-task-apis-polyfills/.prettierrc` had `trailingComma: "es5"`, which is neither what the rest of my code uses nor what prettier 3 defaults to. This switches it to `"all"` and picks up the two other settings my global config has:

- `embeddedLanguageFormatting: "auto"`
- an override setting `singleQuote: false` for `**/*.css` and `**/*.scss`, since `singleQuote` applies to css strings and `url()` too

`prettier-plugin-curly` stays, it is specific to this package.

The rest of the diff is `npx prettier --write .` over the package: added trailing commas, no syntactic changes. `prettier --check` is clean and `eslint .` reports only the two issues that were already there (`WorkerGlobalScope` in the semantic embedder, the unused `setupPolyfillModeBanner`).

No version bump, since nothing about the published behavior changes.