### PR TITLE
Add streaming-markdown-html, an append-only Markdown-to-HTML parser

### DIFF
--- a/streaming-markdown-html/.gitignore
+++ b/streaming-markdown-html/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+types/
+*.tgz

--- a/streaming-markdown-html/.prettierignore
+++ b/streaming-markdown-html/.prettierignore
@@ -1,0 +1,2 @@
+node_modules/
+types/

--- a/streaming-markdown-html/.prettierrc
+++ b/streaming-markdown-html/.prettierrc
@@ -1,0 +1,10 @@
+{
+  "singleQuote": true,
+  "trailingComma": "es5",
+  "overrides": [
+    {
+      "files": "*.md",
+      "options": { "embeddedLanguageFormatting": "off" }
+    }
+  ]
+}

--- a/streaming-markdown-html/LICENSE
+++ b/streaming-markdown-html/LICENSE
@@ -1,0 +1,30 @@
+This package contains work under two licences.
+
+parser.js is derived from streaming-markdown by Damian Tarnawski, under the
+MIT licence. Its full notice is at the top of that file.
+
+    MIT License
+
+    Copyright (c) 2024 Damian Tarnawski
+    Copyright (c) 2026 Google LLC
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+
+Every other file is Copyright 2026 Google LLC and licensed under the Apache
+License, Version 2.0. A copy is at http://www.apache.org/licenses/LICENSE-2.0

--- a/streaming-markdown-html/README.md
+++ b/streaming-markdown-html/README.md
@@ -1,0 +1,188 @@
+<!--
+  Copyright 2026 Google LLC
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# streaming-markdown-html
+
+A streaming Markdown-to-HTML parser for browsers. It's append-only: as Markdown
+arrives it emits new HTML and never revises what it already emitted, so the page
+can grow a token at a time instead of being re-rendered on every chunk. That is
+what makes it a fit for a language model's output, which arrives a few
+characters at a time.
+
+Two things make it browser-specific on purpose:
+
+- **Output granularity is one token**, not one block. A paragraph appears word
+  by word rather than all at once when it ends.
+- **Nothing needs an HTML string sink.** `renderStreamingHTML()` builds the DOM
+  with `createElement`, `setAttribute`, and `append` alone, so it works on pages
+  that enforce Trusted Types, where `innerHTML` and `insertAdjacentHTML` throw.
+
+## Install
+
+```sh
+npm install streaming-markdown-html
+```
+
+It needs a DOM, so it runs in a browser rather than in Node: both entry points
+reach for `document`. It has no runtime dependencies, and ships TypeScript
+declarations.
+
+## Markdown in, HTML chunks out
+
+The `createHtmlTokenStreamer()` function takes Markdown a piece at a time and
+calls you back with HTML:
+
+```js
+import { createHtmlTokenStreamer } from 'streaming-markdown-html';
+
+const streamer = createHtmlTokenStreamer({
+  onHtml: (html) => console.log(html), // '<p>', 'Hello ', 'world', '</p>'
+  // A `javascript:` href, or any other scheme outside http(s), mailto, tel,
+  // sms, ftp and image `data:` URLs. The attribute is dropped either way;
+  // this is the notification.
+  onUnsafe: ({ attribute, value }) => console.warn(attribute, value),
+});
+streamer.write('Hello ');
+streamer.write('world');
+streamer.end(); // Closes whatever tags the Markdown left open.
+```
+
+A chunk is one opening tag, one run of text, or one closing tag, never a
+balanced fragment: `<p>` arrives before its text and `</p>` long after.
+Concatenating them all gives the complete, well-formed HTML.
+
+## Putting those chunks on the page
+
+If the Markdown already arrives as a stream, the whole thing is one expression.
+The `markdownToHtml()` transform is the streamer above as a `TransformStream`,
+and
+`renderStreamingHTML(element)` is a `WritableStream` that builds the DOM as the
+chunks arrive, appending nodes rather than re-parsing anything:
+
+```js
+import {
+  markdownToHtml,
+  renderStreamingHTML,
+} from 'streaming-markdown-html';
+
+await markdownStream
+  .pipeThrough(markdownToHtml())
+  .pipeTo(renderStreamingHTML(document.querySelector('#out')));
+```
+
+Keeping each chunk to a single token is what makes that last step possible
+without an HTML string sink: a balanced fragment would need
+`insertAdjacentHTML`. Because it's an ordinary pipeline, a `TransformStream` in
+the middle sees the HTML on its way past, and backpressure works the way it
+does anywhere else.
+
+The `isSafeUrl(value)` helper is exported too, for callers that want the same
+check elsewhere.
+
+## With the Prompt API
+
+`LanguageModel` streams Markdown, which is exactly what the pipeline above
+takes. Its `promptStreaming()` returns a `ReadableStream`, so rendering a
+response
+as it is generated is those same three lines:
+
+```js
+import {
+  markdownToHtml,
+  renderStreamingHTML,
+} from 'streaming-markdown-html';
+
+const session = await LanguageModel.create();
+const output = document.querySelector('#out');
+
+await session
+  .promptStreaming('Explain streams, with a short table.')
+  .pipeThrough(markdownToHtml())
+  .pipeTo(renderStreamingHTML(output));
+```
+
+A model's chunks split wherever the tokenizer happened to split them, mid-word
+and mid-construct, which is the case this parser is built for: a `**bold**` or a
+table row spread over three chunks is held until it is complete, and nothing
+already on the page is touched again.
+
+Two things this does not do, both of which matter if the prompt is anything a
+user can influence. It does not vet the Markdown: a model told to emit
+`<img src=x onerror=…>` will emit it, and while this parser escapes it into text
+rather than markup, you want to know it happened. And it does not stop the
+response. For both, see
+[`easy-language-model`](https://github.com/GoogleChromeLabs/web-ai-demos/tree/main/easy-language-model),
+a Prompt API wrapper that runs the response through the
+[Sanitizer API](https://developer.mozilla.org/en-US/docs/Web/API/HTML_Sanitizer_API)
+and uses this package underneath.
+
+## Prior art
+
+This is not a parser written from scratch. It is a fork of
+[streaming-markdown](https://github.com/thetarnav/streaming-markdown) 0.2.15 by
+Damian Tarnawski (MIT), which is where the append-only design and the whole
+tokenizer come from. That design is the hard part and the reason for building on
+it: emitting only new tokens is what lets a caller append to the DOM instead of
+re-rendering.
+
+It is a fork rather than a dependency because upstream is unmaintained. The last
+substantive commit was May 2025 and it describes itself as an experiment, so
+there was nowhere to send these fixes. Each one lives in
+[`parser.js`](parser.js), marked with a `FIX:` comment, and is measured against
+a CommonMark + GFM reference:
+
+|                                      | Before                                             | After                        |
+| ------------------------------------ | -------------------------------------------------- | ---------------------------- |
+| `snake_case_word`, `MAX_BUFFER_SIZE` | `snake<em>case</em>word`                           | kept literal, per CommonMark |
+| `~~~` code fences                    | mangled into strikethrough                         | parsed as a fence            |
+| `&amp;`, `&copy;`, `&#65;`           | double-escaped, shown literally                    | resolved                     |
+| `[t](url "Title")`                   | title swallowed into the `href`, breaking the link | `title` attribute            |
+| `![alt](src)`                        | alt text silently dropped                          | `alt` attribute              |
+| Fenced code language                 | `class="js"`                                       | `class="language-js"`        |
+| Table cells                          | padded with the spaces from `\| a \|`              | trimmed                      |
+| `~~text~~`                           | `<s>`                                              | `<del>`, as GFM specifies    |
+
+Every construct is tested at several chunk sizes, because a model's chunk
+boundaries land mid-construct and several of these bugs only appear there.
+
+## Known deviations
+
+These are deliberately not supported, and each is pinned by a test in
+[`test/markdown.test.js`](test/markdown.test.js) so a future fix shows up as a
+failure rather than a silent change:
+
+- **Setext headings** (`Title` over `=====`), and anything about a list that is
+  only knowable after the fact: whether it is loose, and whether a second
+  paragraph belongs to the item above it. Each is recognizable only once the
+  content it affects has been emitted, and an append-only parser cannot revise
+  what it emitted. Supporting them means holding every paragraph back by a line,
+  which is the cost this design exists to avoid. Models use `#` headings
+  essentially always.
+- **Block constructs inside a list item.** `- # h` keeps the `#` as text.
+- **Reference links** (`[t][r]` with a `[r]: url` definition). The definition
+  can appear anywhere later in the document, so resolving it needs a second
+  pass. The anchors come out without an `href`, so they render as plain text
+  rather than as dead links.
+- **Angle-bracket autolinks** (`<https://example.com/>`). Making `<` open a link
+  risks swallowing the `<placeholder>` text that model prose is full of. Bare
+  URLs and `[text](url)` links both work.
+- **Table column alignment**. The reference parser emits the deprecated `align`
+  attribute, which sanitizers strip anyway.
+- **The space before a two-space hard break**, which is kept rather than
+  trimmed. It renders identically.
+
+## Note on entity references
+
+Resolving `&copy;` needs the full HTML entity table, so the browser's own parser
+does it, through `setHTML()` rather than `innerHTML`: pages enforcing Trusted
+Types refuse `innerHTML`, and refusing it here would break every response
+containing an entity rather than only an unsafe one. Where `setHTML()` is
+missing, references are left literal rather than throwing.
+
+## Licence
+
+[`parser.js`](parser.js) is MIT, © 2024 Damian Tarnawski, with modifications ©
+2026 Google LLC. The full notice is at the top of the file. Everything else is
+Apache-2.0, © 2026 Google LLC.

--- a/streaming-markdown-html/index.js
+++ b/streaming-markdown-html/index.js
@@ -1,0 +1,9 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export { createHtmlTokenStreamer } from './renderer.js';
+export { markdownToHtml } from './markdown-to-html.js';
+export { renderStreamingHTML } from './render-stream.js';
+export { isSafeUrl } from './safe-url.js';

--- a/streaming-markdown-html/markdown-to-html.js
+++ b/streaming-markdown-html/markdown-to-html.js
@@ -1,0 +1,48 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { createHtmlTokenStreamer } from './renderer.js';
+
+/**
+ * A `TransformStream` that takes Markdown chunks and emits HTML chunks.
+ *
+ * This is `createHtmlTokenStreamer()` with a stream on either side, which is
+ * what lets a Markdown source reach the page in one expression:
+ *
+ * ```js
+ * await markdownStream
+ *   .pipeThrough(markdownToHtml())
+ *   .pipeTo(renderStreamingHTML(output));
+ * ```
+ *
+ * Chunk boundaries on the way in don't have to line up with anything: a
+ * construct split across two writes is held until it is complete.
+ *
+ * @param {object} [options]
+ * @param {(detail: {attribute: string, value: string}) => void} [options.onUnsafe]
+ *   Called when an `href` or `src` is dropped for having an unsafe scheme.
+ * @returns {TransformStream<string, string>}
+ */
+export function markdownToHtml({ onUnsafe } = {}) {
+  /** @type {ReturnType<typeof createHtmlTokenStreamer>} */
+  let streamer;
+
+  return new TransformStream({
+    start(controller) {
+      streamer = createHtmlTokenStreamer({
+        onHtml: (html) => controller.enqueue(html),
+        onUnsafe,
+      });
+    },
+    transform(markdown) {
+      streamer.write(markdown);
+    },
+    flush() {
+      // Closes whatever tags the Markdown left open. The controller still
+      // accepts chunks here, so those closing tags make it out.
+      streamer.end();
+    },
+  });
+}

--- a/streaming-markdown-html/package-lock.json
+++ b/streaming-markdown-html/package-lock.json
@@ -1,0 +1,724 @@
+{
+  "name": "streaming-markdown-html",
+  "version": "0.1.1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "streaming-markdown-html",
+      "version": "0.1.1",
+      "license": "(Apache-2.0 AND MIT)",
+      "devDependencies": {
+        "linkedom": "^0.18.13",
+        "marked": "^18.0.11",
+        "prettier": "^3.4.2",
+        "typescript": "^7.0.2"
+      }
+    },
+    "node_modules/@typescript/typescript-aix-ppc64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-aix-ppc64/-/typescript-aix-ppc64-7.0.2.tgz",
+      "integrity": "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-darwin-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-arm64/-/typescript-darwin-arm64-7.0.2.tgz",
+      "integrity": "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-darwin-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-x64/-/typescript-darwin-x64-7.0.2.tgz",
+      "integrity": "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-freebsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-arm64/-/typescript-freebsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-freebsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-x64/-/typescript-freebsd-x64-7.0.2.tgz",
+      "integrity": "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-arm": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm/-/typescript-linux-arm-7.0.2.tgz",
+      "integrity": "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm64/-/typescript-linux-arm64-7.0.2.tgz",
+      "integrity": "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-loong64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-loong64/-/typescript-linux-loong64-7.0.2.tgz",
+      "integrity": "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-mips64el": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-mips64el/-/typescript-linux-mips64el-7.0.2.tgz",
+      "integrity": "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-ppc64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-ppc64/-/typescript-linux-ppc64-7.0.2.tgz",
+      "integrity": "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-riscv64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-riscv64/-/typescript-linux-riscv64-7.0.2.tgz",
+      "integrity": "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-s390x": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-s390x/-/typescript-linux-s390x-7.0.2.tgz",
+      "integrity": "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-x64/-/typescript-linux-x64-7.0.2.tgz",
+      "integrity": "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-netbsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-arm64/-/typescript-netbsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-netbsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-x64/-/typescript-netbsd-x64-7.0.2.tgz",
+      "integrity": "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-openbsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-arm64/-/typescript-openbsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-openbsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-x64/-/typescript-openbsd-x64-7.0.2.tgz",
+      "integrity": "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-sunos-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-sunos-x64/-/typescript-sunos-x64-7.0.2.tgz",
+      "integrity": "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-win32-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-arm64/-/typescript-win32-arm64-7.0.2.tgz",
+      "integrity": "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-win32-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-x64/-/typescript-win32-x64-7.0.2.tgz",
+      "integrity": "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/boolbase": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-2.0.0.tgz",
+      "integrity": "sha512-DkVaaQHymRhpYEYo9x1oo7Q7B0Y6KJUsjm3c9eTyFDby4MHLBTwZ6ZDWBel5zrYxj1WsZgC5oLpiz+93MluXeA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-select": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-7.0.0.tgz",
+      "integrity": "sha512-snmjEVXy+1LnwXdxhYvTMj1d9tOh4HxkA1YmoayVBeeyR2C14Pum7fcxJIm4SswYspVy866eYNwlH6xC3/VH5g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^2.0.0",
+        "css-what": "^8.0.0",
+        "domhandler": "^6.0.1",
+        "domutils": "^4.0.2",
+        "nth-check": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-8.0.0.tgz",
+      "integrity": "sha512-DH0Bqq3DNp5tdOReuNyAA+Ev4Y2GS5FMbZpeTLP6C4CDi0h5nL0BmUPChXw3o/qbHLDWHl49sbNqQVY7bMSDdw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/cssom": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.5.0.tgz",
+      "integrity": "sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/dom-serializer": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-3.1.1.tgz",
+      "integrity": "sha512-4MEa38/QexBob6gFNwu+EGdWvhJ1OKuNwdYY3Y3NyeWDQfnGeDYQUDfIRzWu5B5gsv03so2Uxd28YC6zrsx3Lw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^3.0.0",
+        "domhandler": "^6.0.0",
+        "entities": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-3.0.0.tgz",
+      "integrity": "sha512-umCQid3jKbDmVjx8jGaW7uUykm4DEUeyV21hPxNMo2nV955DhUThwqyOIDtreepP31hl84X7G5U9ZfsWvIB3Pg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/domhandler": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-6.0.1.tgz",
+      "integrity": "sha512-gYzvtM72ZtxQO0T048kd6HWSbbGCNOUwcnfQ01cqIJ4X2IYKFFHZ5mKvrQETcFXxsRObZulDaKmy//R7TPtsBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-4.0.2.tgz",
+      "integrity": "sha512-qI4JLRKnSzqFqr7hAlS5xQDusBCjKSEG4t4+7aNrIQMHBcsC2TGEhuyABJdYkgSewL57PNLYEiibY2iPKhKpaA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^3.0.0",
+        "domelementtype": "^3.0.0",
+        "domhandler": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-3.0.3.tgz",
+      "integrity": "sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/htmlparser2": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
+      "integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "entities": "^7.0.1"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/dom-serializer/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/htmlparser2/node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/linkedom": {
+      "version": "0.18.13",
+      "resolved": "https://registry.npmjs.org/linkedom/-/linkedom-0.18.13.tgz",
+      "integrity": "sha512-ES/o9qotMpzpN2MHs+Iq/JcVoOj8Fa5wiQYrTdFpvAnwXL0g66XHHUc9WUMk6nAlBtGsFQ24ne+SYnvnaQ2FSw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "css-select": "^7.0.0",
+        "cssom": "^0.5.0",
+        "html-escaper": "^3.0.3",
+        "htmlparser2": "^10.1.0",
+        "uhyphen": "^0.2.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "canvas": ">= 2"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/marked": {
+      "version": "18.0.11",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.11.tgz",
+      "integrity": "sha512-HnslJfsZkRPBDJRHvVtAaWlZHEpSu7u8LgQuJCELjRKuWR+hpq4A7sLq3p8HaI9ypVoXDXxV34CsQJEe1+J5Aw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/nth-check": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-3.0.1.tgz",
+      "integrity": "sha512-GX0gsdbGVCgnRgbeGaubfjpBXyYRWOOCVeYh08bSQvDZqxz5ndXs1OTfAt/h36G1xvI94YIspsI0sVFqAV9+RQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.9.6",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.6.tgz",
+      "integrity": "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-7.0.2.tgz",
+      "integrity": "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc"
+      },
+      "engines": {
+        "node": ">=16.20.0"
+      },
+      "optionalDependencies": {
+        "@typescript/typescript-aix-ppc64": "7.0.2",
+        "@typescript/typescript-darwin-arm64": "7.0.2",
+        "@typescript/typescript-darwin-x64": "7.0.2",
+        "@typescript/typescript-freebsd-arm64": "7.0.2",
+        "@typescript/typescript-freebsd-x64": "7.0.2",
+        "@typescript/typescript-linux-arm": "7.0.2",
+        "@typescript/typescript-linux-arm64": "7.0.2",
+        "@typescript/typescript-linux-loong64": "7.0.2",
+        "@typescript/typescript-linux-mips64el": "7.0.2",
+        "@typescript/typescript-linux-ppc64": "7.0.2",
+        "@typescript/typescript-linux-riscv64": "7.0.2",
+        "@typescript/typescript-linux-s390x": "7.0.2",
+        "@typescript/typescript-linux-x64": "7.0.2",
+        "@typescript/typescript-netbsd-arm64": "7.0.2",
+        "@typescript/typescript-netbsd-x64": "7.0.2",
+        "@typescript/typescript-openbsd-arm64": "7.0.2",
+        "@typescript/typescript-openbsd-x64": "7.0.2",
+        "@typescript/typescript-sunos-x64": "7.0.2",
+        "@typescript/typescript-win32-arm64": "7.0.2",
+        "@typescript/typescript-win32-x64": "7.0.2"
+      }
+    },
+    "node_modules/uhyphen": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/uhyphen/-/uhyphen-0.2.0.tgz",
+      "integrity": "sha512-qz3o9CHXmJJPGBdqzab7qAYuW8kQGKNEuoHFYrBwV6hWIMcpAmxDLXojcHfFr9US1Pe6zUswEIJIbLI610fuqA==",
+      "dev": true,
+      "license": "ISC"
+    }
+  }
+}

--- a/streaming-markdown-html/package.json
+++ b/streaming-markdown-html/package.json
@@ -1,0 +1,55 @@
+{
+  "name": "streaming-markdown-html",
+  "version": "0.1.1",
+  "description": "A streaming Markdown-to-HTML parser for browsers: append-only, token-granularity output you can pipe straight into an element.",
+  "license": "(Apache-2.0 AND MIT)",
+  "author": "Thomas Steiner <tomac@google.com>",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/GoogleChromeLabs/web-ai-demos.git",
+    "directory": "streaming-markdown-html"
+  },
+  "homepage": "https://github.com/GoogleChromeLabs/web-ai-demos/tree/main/streaming-markdown-html#readme",
+  "bugs": "https://github.com/GoogleChromeLabs/web-ai-demos/issues",
+  "type": "module",
+  "main": "./index.js",
+  "types": "./types/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./types/index.d.ts",
+      "default": "./index.js"
+    }
+  },
+  "files": [
+    "index.js",
+    "parser.js",
+    "renderer.js",
+    "markdown-to-html.js",
+    "render-stream.js",
+    "safe-url.js",
+    "types",
+    "README.md",
+    "LICENSE"
+  ],
+  "sideEffects": false,
+  "scripts": {
+    "build": "tsc",
+    "test": "node --test \"test/*.test.js\"",
+    "format": "prettier --write .",
+    "prepublishOnly": "npm test && npm run build"
+  },
+  "keywords": [
+    "markdown",
+    "html",
+    "streaming",
+    "parser",
+    "commonmark",
+    "llm"
+  ],
+  "devDependencies": {
+    "linkedom": "^0.18.13",
+    "marked": "^18.0.11",
+    "prettier": "^3.4.2",
+    "typescript": "^7.0.2"
+  }
+}

--- a/streaming-markdown-html/parser.js
+++ b/streaming-markdown-html/parser.js
@@ -1,0 +1,1881 @@
+/**
+ * Vendored from streaming-markdown 0.2.15 by Damian Tarnawski, MIT licensed.
+ * https://github.com/thetarnav/streaming-markdown
+ *
+ * Copyright (c) 2024 Damian Tarnawski
+ * Copyright (c) 2026 Google LLC
+ * SPDX-License-Identifier: MIT
+ *
+ * Upstream is unmaintained (last substantive commit May 2025) and describes
+ * itself as an experiment, so this copy is where the fixes live. It keeps
+ * upstream's append-only guarantee — the parser only ever emits new tokens, it
+ * never revises what it already emitted — which is what lets a caller build the
+ * DOM by appending and stream HTML at token granularity.
+ *
+ * Changes from upstream, each marked with a `FIX:` comment:
+ *
+ * - `_` only opens emphasis at a word boundary, per CommonMark, so
+ *   snake_case_word and MAX_BUFFER_SIZE keep their underscores. `*` is
+ *   unchanged. This needs `lastTextChar`, because text is flushed to the
+ *   renderer at arbitrary points and a chunk boundary can empty the buffer
+ *   right before the delimiter.
+ * - `~~~` opens a code fence, alongside ```. `fenceChar` records which
+ *   character opened it so the right one closes it. `~~strikethrough~~` still
+ *   works: two tildes not followed by a third fail out to the inline path.
+ *
+ * - Entity references in text are resolved, so `AT&amp;T` and `&copy;` come out
+ *   as `AT&T` and ©. A reference split across two chunks is held back until the
+ *   rest of it arrives. Code spans and code blocks keep theirs literal.
+ * - A table cell's content is trimmed, as GFM specifies, rather than carrying
+ *   the padding from `| a |` through as text.
+ * - `[t](url "Title")` splits the title off instead of swallowing it into the
+ *   destination, where it broke the link.
+ * - `![alt](src)` keeps its alt text, accumulated through `altText` because it
+ *   arrives in pieces and ends up as an attribute rather than as text.
+ * - A fenced block's language becomes `language-js`, the convention syntax
+ *   highlighters look for, rather than a bare `js`.
+ * - `~~text~~` is `<del>`, which is what GFM specifies, rather than `<s>`.
+ *
+ * `tokenToTags()` names the HTML element each token becomes, so a renderer
+ * doesn't have to carry its own copy of that mapping. The built-in DOM and
+ * logger renderers were dropped; `renderer.js` has the one this package uses.
+ *
+ * Every snake_case identifier was renamed to camelCase to match the rest of
+ * this project. SCREAMING_SNAKE constants kept their convention. That makes a
+ * line-by-line diff against upstream useless, which is a deliberate trade: this
+ * is a fork rather than a patched copy, and there is no upstream left to track.
+ */
+
+/*
+Streaming Markdown Parser and Renderer
+MIT License
+Copyright 2024 Damian Tarnawski
+https://github.com/thetarnav/streaming-markdown
+*/
+
+export const DOCUMENT = 1,
+  PARAGRAPH = 2,
+  HEADING_1 = 3,
+  HEADING_2 = 4,
+  HEADING_3 = 5,
+  HEADING_4 = 6,
+  HEADING_5 = 7,
+  HEADING_6 = 8,
+  CODE_BLOCK = 9,
+  CODE_FENCE = 10,
+  CODE_INLINE = 11,
+  ITALIC_AST = 12,
+  ITALIC_UND = 13,
+  STRONG_AST = 14,
+  STRONG_UND = 15,
+  STRIKE = 16,
+  LINK = 17,
+  RAW_URL = 18,
+  IMAGE = 19,
+  BLOCKQUOTE = 20,
+  LINE_BREAK = 21,
+  RULE = 22,
+  LIST_UNORDERED = 23,
+  LIST_ORDERED = 24,
+  LIST_ITEM = 25,
+  CHECKBOX = 26,
+  TABLE = 27,
+  TABLE_ROW = 28,
+  TABLE_CELL = 29,
+  EQUATION_BLOCK = 30,
+  EQUATION_INLINE = 31,
+  NEWLINE = 101,
+  MAYBE_URL = 102,
+  MAYBE_TASK = 103,
+  MAYBE_BR = 104,
+  MAYBE_EQ_BLOCK = 105;
+
+/** @enum {(typeof Token)[keyof typeof Token]} */
+export const Token = /** @type {const} */ ({
+  Document: DOCUMENT,
+  Blockquote: BLOCKQUOTE,
+  Paragraph: PARAGRAPH,
+  Heading1: HEADING_1,
+  Heading2: HEADING_2,
+  Heading3: HEADING_3,
+  Heading4: HEADING_4,
+  Heading5: HEADING_5,
+  Heading6: HEADING_6,
+  CodeBlock: CODE_BLOCK,
+  CodeFence: CODE_FENCE,
+  CodeInline: CODE_INLINE,
+  ItalicAst: ITALIC_AST,
+  ItalicUnd: ITALIC_UND,
+  StrongAst: STRONG_AST,
+  StrongUnd: STRONG_UND,
+  Strike: STRIKE,
+  Link: LINK,
+  RawURL: RAW_URL,
+  Image: IMAGE,
+  LineBreak: LINE_BREAK,
+  Rule: RULE,
+  ListUnordered: LIST_UNORDERED,
+  ListOrdered: LIST_ORDERED,
+  ListItem: LIST_ITEM,
+  Checkbox: CHECKBOX,
+  Table: TABLE,
+  TableRow: TABLE_ROW,
+  TableCell: TABLE_CELL,
+  EquationBlock: EQUATION_BLOCK,
+  EquationInline: EQUATION_INLINE,
+});
+
+/**
+ * @param   {Token} type
+ * @returns {string    } */
+export function tokenToString(type) {
+  switch (type) {
+    case DOCUMENT:
+      return 'Document';
+    case BLOCKQUOTE:
+      return 'Blockquote';
+    case PARAGRAPH:
+      return 'Paragraph';
+    case HEADING_1:
+      return 'Heading1';
+    case HEADING_2:
+      return 'Heading2';
+    case HEADING_3:
+      return 'Heading3';
+    case HEADING_4:
+      return 'Heading4';
+    case HEADING_5:
+      return 'Heading5';
+    case HEADING_6:
+      return 'Heading6';
+    case CODE_BLOCK:
+      return 'CodeBlock';
+    case CODE_FENCE:
+      return 'CodeFence';
+    case CODE_INLINE:
+      return 'CodeInline';
+    case ITALIC_AST:
+      return 'ItalicAst';
+    case ITALIC_UND:
+      return 'ItalicUnd';
+    case STRONG_AST:
+      return 'StrongAst';
+    case STRONG_UND:
+      return 'StrongUnd';
+    case STRIKE:
+      return 'Strike';
+    case LINK:
+      return 'Link';
+    case RAW_URL:
+      return 'Raw URL';
+    case IMAGE:
+      return 'Image';
+    case LINE_BREAK:
+      return 'LineBreak';
+    case RULE:
+      return 'Rule';
+    case LIST_UNORDERED:
+      return 'ListUnordered';
+    case LIST_ORDERED:
+      return 'ListOrdered';
+    case LIST_ITEM:
+      return 'ListItem';
+    case CHECKBOX:
+      return 'Checkbox';
+    case TABLE:
+      return 'Table';
+    case TABLE_ROW:
+      return 'TableRow';
+    case TABLE_CELL:
+      return 'TableCell';
+    case EQUATION_BLOCK:
+      return 'EquationBlock';
+    case EQUATION_INLINE:
+      return 'EquationInline';
+  }
+}
+
+/*  FIX: CommonMark resolves entity references in text; upstream passed them
+    through, so `AT&amp;T` rendered as the literal `AT&amp;T` and `&copy;` never
+    became ©. Resolving needs the full HTML entity table, so the browser's own
+    parser does it, through setHTML() rather than innerHTML: pages enforcing
+    Trusted Types refuse innerHTML, and refusing it here would break every
+    response containing an entity rather than only an unsafe one.
+*/
+const ENTITY =
+  /&(?:#\d{1,7}|#[xX][0-9a-fA-F]{1,6}|[a-zA-Z][a-zA-Z0-9]{1,31});/g;
+/** A reference cut short by a chunk boundary, held until the rest arrives. */
+const PARTIAL_ENTITY = /&[a-zA-Z#]?[a-zA-Z0-9]{0,31}$/;
+const entityCache = new Map();
+let entityProbe = null;
+
+function decodeEntities(text) {
+  if (!text.includes('&')) return text;
+  if (entityProbe === null) {
+    entityProbe =
+      typeof document === 'undefined'
+        ? false
+        : document.implementation.createHTMLDocument('').createElement('div');
+    if (entityProbe && typeof entityProbe.setHTML !== 'function') {
+      entityProbe = false;
+    }
+  }
+  // Without the Sanitizer API there is no safe way to resolve a named
+  // reference. Leaving it alone shows `&copy;` literally, which beats throwing.
+  if (entityProbe === false) return text;
+
+  return text.replace(ENTITY, (entity) => {
+    let decoded = entityCache.get(entity);
+    if (decoded === undefined) {
+      entityProbe.setHTML(entity);
+      decoded = entityProbe.textContent || entity;
+      entityCache.set(entity, decoded);
+    }
+    return decoded;
+  });
+}
+
+/**
+ * The HTML element a token becomes.
+ *
+ * FIX: upstream left this to each renderer, which made sense when it aimed to
+ * be renderer-agnostic. This parser targets HTML, so the vocabulary lives here:
+ * one place decides that a strike is `<del>` and a fence is `<pre><code>`.
+ *
+ * A fence needs two elements, so this returns an array, outermost first. Table
+ * rows and cells are the exception and stay with the renderer, since `<thead>`
+ * versus `<tbody>` and `<th>` versus `<td>` depend on where in the table the
+ * token lands rather than on the token itself.
+ *
+ * @param   {Token} type
+ * @returns {string[]}
+ */
+export function tokenToTags(type) {
+  switch (type) {
+    case BLOCKQUOTE:
+      return ['blockquote'];
+    case PARAGRAPH:
+      return ['p'];
+    case LINE_BREAK:
+      return ['br'];
+    case RULE:
+      return ['hr'];
+    case HEADING_1:
+    case HEADING_2:
+    case HEADING_3:
+    case HEADING_4:
+    case HEADING_5:
+    case HEADING_6:
+      return [`h${headingToLevel(type)}`];
+    case ITALIC_AST:
+    case ITALIC_UND:
+      return ['em'];
+    case STRONG_AST:
+    case STRONG_UND:
+      return ['strong'];
+    case STRIKE:
+      return ['del'];
+    case CODE_INLINE:
+      return ['code'];
+    case RAW_URL:
+    case LINK:
+      return ['a'];
+    case IMAGE:
+      return ['img'];
+    case LIST_UNORDERED:
+      return ['ul'];
+    case LIST_ORDERED:
+      return ['ol'];
+    case LIST_ITEM:
+      return ['li'];
+    case CHECKBOX:
+      return ['input'];
+    case CODE_BLOCK:
+    case CODE_FENCE:
+      return ['pre', 'code'];
+    case TABLE:
+      return ['table'];
+    case EQUATION_BLOCK:
+      return ['equation-block'];
+    case EQUATION_INLINE:
+      return ['equation-inline'];
+    default:
+      return ['span'];
+  }
+}
+
+export const HREF = 1,
+  SRC = 2,
+  LANG = 4,
+  CHECKED = 8,
+  START = 16,
+  /*  FIX: upstream had neither. A link's title was left glued to the end of
+      its href, and an image's alt text was emitted as a child of the <img>,
+      where it serializes away.
+  */
+  TITLE = 32,
+  ALT = 64;
+
+/** @enum {(typeof Attr)[keyof typeof Attr]} */
+export const Attr = /** @type {const} */ ({
+  Href: HREF,
+  Src: SRC,
+  Lang: LANG,
+  Checked: CHECKED,
+  Start: START,
+  Title: TITLE,
+  Alt: ALT,
+});
+
+/**
+ * @param   {Attr} type
+ * @returns {string    } */
+export function attrToHtmlAttr(type) {
+  switch (type) {
+    case HREF:
+      return 'href';
+    case SRC:
+      return 'src';
+    case LANG:
+      return 'class';
+    case CHECKED:
+      return 'checked';
+    case START:
+      return 'start';
+    case TITLE:
+      return 'title';
+    case ALT:
+      return 'alt';
+  }
+}
+
+/**
+ * @param   {number} level
+ * @returns {Token } */
+export const levelToHeading = (level) => {
+  switch (level) {
+    case 1:
+      return HEADING_1;
+    case 2:
+      return HEADING_2;
+    case 3:
+      return HEADING_3;
+    case 4:
+      return HEADING_4;
+    case 5:
+      return HEADING_5;
+    default:
+      return HEADING_6;
+  }
+};
+export const headingFromLevel = levelToHeading;
+
+/**
+ * @param   {Token} token
+ * @returns {number} */
+export const headingToLevel = (token) => {
+  switch (token) {
+    case HEADING_1:
+      return 1;
+    case HEADING_2:
+      return 2;
+    case HEADING_3:
+      return 3;
+    case HEADING_4:
+      return 4;
+    case HEADING_5:
+      return 5;
+    case HEADING_6:
+      return 6;
+    default:
+      return 0;
+  }
+};
+
+/**
+ * @typedef  {object      } Parser
+ * @property {AnyRenderer} renderer        - {@link Renderer} interface
+ * @property {string      } text            - Text to be added to the last token in the next flush
+ * @property {string      } pending         - Characters for identifying tokens
+ * @property {Uint32Array } tokens          - Current token and it's parents (a slice of a tree)
+ * @property {number      } len             - Number of tokens in types without root
+ * @property {number      } token           - Last token in the tree
+ * @property {Uint8Array  } spaces
+ * @property {string      } indent
+ * @property {number      } indentLen
+ * @property {number      } fenceEnd       - For {@link Token.CodeFence} parsing
+ * @property {number      } fenceStart
+ * @property {string      } fenceChar      - FIX: ` or ~, whichever opened the fence
+ * @property {string      } lastTextChar  - FIX: last character handed to the renderer
+ * @property {number      } blockquoteIdx  - For Blockquote parsing
+ * @property {string      } hrChar         - For horizontal rule parsing
+ * @property {number      } hrChars        - For horizontal rule parsing
+ * @property {number      } tableState
+ */
+
+const TOKEN_ARRAY_CAP = 24;
+
+/**
+ * Makes a new Parser object.
+ * @param   {AnyRenderer} renderer
+ * @returns {Parser      } */
+export function parser(renderer) {
+  const tokens = new Uint32Array(TOKEN_ARRAY_CAP);
+  tokens[0] = DOCUMENT;
+  return {
+    renderer: renderer,
+    text: '',
+    pending: '',
+    tokens: tokens,
+    len: 0,
+    token: DOCUMENT,
+    fenceEnd: 0,
+    blockquoteIdx: 0,
+    hrChar: '',
+    hrChars: 0,
+    fenceStart: 0,
+    fenceChar: '',
+    lastTextChar: '',
+    altText: '', // FIX: an image's alt arrives in pieces; see addText
+    trimCellStart: false, // FIX: see addText
+    entityTail: '', // FIX: a reference split across chunks; see addText
+    spaces: new Uint8Array(TOKEN_ARRAY_CAP),
+    indent: '',
+    indentLen: 0,
+    tableState: 0,
+  };
+}
+
+/**
+ * Finish rendering the markdown - flushes any remaining text.
+ * @param   {Parser} p
+ * @returns {void  } */
+export function parserEnd(p) {
+  if (p.pending.length > 0) {
+    parserWrite(p, '\n');
+  }
+}
+
+/**
+ * @param   {Parser} p
+ * @returns {void  } */
+function addText(p) {
+  if (p.text.length === 0) return;
+  console.assert(p.len > 0, 'Never adding text to root');
+  /*  FIX: `![alt](src)` delivers the alt as text. An <img> has no children, so
+      a renderer would drop it; it is an attribute.
+  */
+  if (p.tokens[p.len] === IMAGE) {
+    // Held until the image closes: the text arrives in pieces, and an
+    // attribute is set, not appended.
+    p.altText += p.text;
+    p.text = '';
+    return;
+  }
+  /*  FIX: GFM trims a table cell's content. Upstream emitted the padding from
+      `| a |` as text, leaving every renderer to undo it. The leading run goes
+      at the start of the cell, the trailing run when it closes.
+  */
+  if (p.tokens[p.len] === TABLE_CELL) {
+    if (p.trimCellStart) {
+      p.text = p.text.replace(/^[ \t]+/, '');
+      if (p.text !== '') p.trimCellStart = false;
+    }
+    if (p.pending === '|' || p.pending === '\n') {
+      p.text = p.text.replace(/[ \t]+$/, '');
+    }
+    if (p.text === '') return;
+  }
+  /*  FIX: the emphasis rules need the character before a delimiter, but text
+        is flushed at arbitrary points — a chunk boundary can empty p.text right
+        before an `_`. Remember the last character that went out.
+    */
+  p.lastTextChar = p.text[p.text.length - 1];
+
+  // References are literal inside code, and are resolved everywhere else.
+  const token = p.tokens[p.len];
+  if (token === CODE_INLINE || token === CODE_FENCE || token === CODE_BLOCK) {
+    p.renderer.addText(p.renderer.data, p.text);
+    p.text = '';
+    return;
+  }
+
+  let text = p.entityTail + p.text;
+  p.entityTail = '';
+  const partial = PARTIAL_ENTITY.exec(text);
+  if (partial) {
+    p.entityTail = partial[0];
+    text = text.slice(0, partial.index);
+  }
+  p.text = '';
+  if (text !== '') {
+    p.renderer.addText(p.renderer.data, decodeEntities(text));
+  }
+}
+
+/** Emits a held-back partial reference literally; it was never completed. */
+function flushEntityTail(p) {
+  if (p.entityTail === '' || p.len === 0) return;
+  const text = p.entityTail;
+  p.entityTail = '';
+  p.renderer.addText(p.renderer.data, text);
+}
+
+/**
+ * @param   {Parser} p
+ * @returns {void  } */
+function ensureParagraph(p) {
+  switch (p.token) {
+    case LINE_BREAK:
+    case DOCUMENT:
+    case BLOCKQUOTE:
+    case LIST_ORDERED:
+    case LIST_UNORDERED:
+      addToken(p, PARAGRAPH);
+  }
+}
+
+/**
+ * @param   {Parser} p
+ * @param   {string} text
+ * @returns {void  } */
+function pushText(p, text) {
+  ensureParagraph(p);
+  p.text += text;
+}
+
+/**
+ * @param   {Parser} p
+ * @returns {void  } */
+function endToken(p) {
+  flushEntityTail(p); // FIX: see addText
+  p.lastTextChar = '';
+  console.assert(p.len > 0, 'No nodes to end');
+  p.len -= 1;
+  p.token = /** @type {Token} */ (p.tokens[p.len]);
+  p.renderer.endToken(p.renderer.data);
+}
+
+/**
+ * @param   {Parser} p
+ * @param   {Token } token
+ * @returns {void  } */
+function addToken(p, token) {
+  flushEntityTail(p); // FIX: see addText
+  p.lastTextChar = '';
+  if (token === IMAGE) {
+    p.altText = '';
+  }
+  if (token === TABLE_CELL) {
+    p.trimCellStart = true;
+  }
+  /*
+     If a list doesn't start with a list item
+     it means that there was a newline after the list:
+
+     1. foo
+     2. bar
+     <empty line>
+     <notAListItem> <- new token
+    */
+  if (
+    (p.tokens[p.len] === LIST_ORDERED || p.tokens[p.len] === LIST_UNORDERED) &&
+    token !== LIST_ITEM
+  ) {
+    endToken(p);
+  }
+
+  p.len += 1;
+  p.tokens[p.len] = token;
+  p.token = token;
+  p.renderer.addToken(p.renderer.data, token);
+}
+
+/**
+ * @param   {Parser} p
+ * @param   {number} token
+ * @param   {number} startIdx
+ * @returns {number} */
+function idxOfToken(p, token, startIdx) {
+  while (startIdx <= p.len) {
+    if (p.tokens[startIdx] === token) {
+      return startIdx;
+    }
+    startIdx += 1;
+  }
+  return -1;
+}
+
+/**
+ * End tokens until the parser has the given length.
+ * @param   {Parser} p
+ * @param   {number} len
+ * @returns {void  } */
+function endTokensToLen(p, len) {
+  // TODO: specific token state should be reset only when the token ends
+  p.fenceStart = 0;
+
+  while (p.len > len) {
+    endToken(p);
+  }
+}
+
+/**
+ * @param   {Parser} p
+ * @param   {number} indent
+ * @returns {number} */
+function endTokensToIndent(p, indent) {
+  let idx = 0;
+  for (let i = 0; i <= p.len; i += 1) {
+    indent -= p.spaces[i];
+    if (indent < 0) {
+      break;
+    }
+    switch (p.tokens[i]) {
+      case CODE_BLOCK:
+      case CODE_FENCE:
+      case BLOCKQUOTE:
+      case LIST_ITEM:
+        idx = i;
+        break;
+    }
+  }
+
+  while (p.len > idx) {
+    endToken(p);
+  }
+
+  return indent;
+}
+
+/**
+ * @param   {Parser } p
+ * @param   {Token  } listToken
+ * @returns {boolean} added a new list */
+function continueOrAddList(p, listToken) {
+  /* will create a new list inside the last item
+       if the amount of spaces is greater than the last one (with prefix)
+       1. foo
+          - bar      <- new nested ul
+             - baz   <- new nested ul
+          12. qux    <- cannot be nested in "baz" or "bar",
+                        so it's a new list in "foo"
+    */
+  let listIdx = -1;
+  let itemIdx = -1;
+
+  for (let i = p.blockquoteIdx + 1; i <= p.len; i += 1) {
+    if (p.tokens[i] === LIST_ITEM) {
+      if (p.indentLen < p.spaces[i]) {
+        itemIdx = -1;
+        break;
+      }
+      itemIdx = i;
+    } else if (p.tokens[i] === listToken) {
+      listIdx = i;
+    }
+  }
+
+  if (itemIdx === -1) {
+    if (listIdx === -1) {
+      endTokensToLen(p, p.blockquoteIdx);
+      addToken(p, listToken);
+      return true;
+    }
+    endTokensToLen(p, listIdx);
+    return false;
+  }
+  endTokensToLen(p, itemIdx);
+  addToken(p, listToken);
+  return true;
+}
+
+/**
+ * Create a new list
+ * or continue the last one
+ * @param   {Parser } p
+ * @param   {number } prefixLength
+ * @returns {void   } */
+function addListItem(p, prefixLength) {
+  addToken(p, LIST_ITEM);
+  p.spaces[p.len] = p.indentLen + prefixLength;
+  clearRootPending(p);
+  p.token = MAYBE_TASK;
+}
+
+/**
+ * @param   {Parser} p
+ * @returns {void  } */
+function clearRootPending(p) {
+  p.indent = '';
+  p.indentLen = 0;
+  p.pending = '';
+}
+
+/**
+ * @param   {number} charcode
+ * @returns {boolean} */
+function isDigit(charcode) {
+  switch (charcode) {
+    case 48:
+    case 49:
+    case 50:
+    case 51:
+    case 52:
+    case 53:
+    case 54:
+    case 55:
+    case 56:
+    case 57:
+      return true;
+    default:
+      return false;
+  }
+}
+
+/**
+ * @param   {number} charcode
+ * @returns {boolean} */
+function isDelimeter(charcode) {
+  switch (charcode) {
+    //   " "      ":"      ";"      ")"      ","      "!"      "."      "?"      "]"      "\n"
+    case 32:
+    case 58:
+    case 59:
+    case 41:
+    case 44:
+    case 33:
+    case 46:
+    case 63:
+    case 93:
+    case 10:
+      return true;
+    default:
+      return false;
+  }
+}
+
+/**
+ * @param   {number} charcode
+ * @returns {boolean} */
+function isDelimeterOrNumber(charcode) {
+  return isDigit(charcode) || isDelimeter(charcode);
+}
+
+/**
+ * @param   {number} charcode
+ * @returns {boolean} */
+function isAlnum(charcode) {
+  return (
+    isDigit(charcode) || // 0-9
+    (charcode >= 65 && charcode <= 90) || // A-Z
+    (charcode >= 97 && charcode <= 122)
+  ); // a-z
+}
+
+/**
+ * Parse and render another chunk of markdown.
+ * @param   {Parser} p
+ * @param   {string} chunk
+ * @returns {void  } */
+export function parserWrite(p, chunk) {
+  for (const char of chunk) {
+    /*
+         Handle newlines
+        */
+    if (p.token === NEWLINE) {
+      switch (char) {
+        case ' ':
+          p.indentLen += 1;
+          continue;
+        case '\t':
+          p.indentLen += 4;
+          continue;
+      }
+
+      let indent = endTokensToIndent(p, p.indentLen);
+
+      p.indentLen = 0;
+      p.token = p.tokens[p.len];
+
+      if (indent > 0) {
+        parserWrite(p, ' '.repeat(indent));
+      }
+    }
+
+    const pendingWithChar = p.pending + char;
+
+    /*
+        Token specific checks
+        */
+    switch (p.token) {
+      case LINE_BREAK:
+      case DOCUMENT:
+      case BLOCKQUOTE:
+      case LIST_ORDERED:
+      case LIST_UNORDERED:
+        console.assert(p.text.length === 0, 'Root should not have any text');
+
+        switch (p.pending[0]) {
+          case undefined:
+            p.pending = char;
+            continue;
+          case ' ':
+            console.assert(p.pending.length === 1);
+            p.pending = char;
+            p.indent += ' ';
+            p.indentLen += 1;
+            continue;
+          case '\t':
+            console.assert(p.pending.length === 1);
+            p.pending = char;
+            p.indent += '\t';
+            p.indentLen += 4;
+            continue;
+          case '\n':
+            console.assert(p.pending.length === 1);
+            /*
+                 Lists can have an empty line in between items:
+                 1. foo
+                 <empty>
+                 2. bar
+                */
+            if (p.tokens[p.len] === LIST_ITEM && p.token === LINE_BREAK) {
+              endToken(p);
+              clearRootPending(p);
+              p.pending = char;
+              continue;
+            }
+            /*
+                 Exit out of tokens
+                 And ignore newlines in root
+                */
+            endTokensToLen(p, p.blockquoteIdx);
+            clearRootPending(p);
+            p.blockquoteIdx = 0;
+            p.fenceStart = 0;
+            p.pending = char;
+            continue;
+          /* Heading */
+          case '#':
+            switch (char) {
+              case '#':
+                if (p.pending.length < 6) {
+                  p.pending = pendingWithChar;
+                  continue;
+                }
+                break; // fail
+              case ' ':
+                endTokensToIndent(p, p.indentLen);
+                addToken(p, headingFromLevel(p.pending.length));
+                clearRootPending(p);
+                continue;
+            }
+            break; // fail
+          /* Blockquote */
+          case '>': {
+            const nextBlockquoteIdx = idxOfToken(
+              p,
+              BLOCKQUOTE,
+              p.blockquoteIdx + 1
+            );
+
+            /*
+                Only when there is no blockquote to the right of blockquoteIdx
+                a new blockquote can be created
+                */
+            if (nextBlockquoteIdx === -1) {
+              endTokensToLen(p, p.blockquoteIdx);
+              p.blockquoteIdx += 1;
+              p.fenceStart = 0;
+              addToken(p, BLOCKQUOTE);
+            } else {
+              p.blockquoteIdx = nextBlockquoteIdx;
+            }
+
+            clearRootPending(p);
+            p.pending = char;
+            continue;
+          }
+          /* Horizontal Rule
+               "-- - --- - --"
+            */
+          case '-':
+          case '*':
+          case '_':
+            if (p.hrChars === 0) {
+              console.assert(
+                p.pending.length === 1,
+                'Pending should be one character'
+              );
+              p.hrChars = 1;
+              p.hrChar = p.pending;
+            }
+
+            if (p.hrChars > 0) {
+              switch (char) {
+                case p.hrChar:
+                  p.hrChars += 1;
+                  p.pending = pendingWithChar;
+                  continue;
+                case ' ':
+                  p.pending = pendingWithChar;
+                  continue;
+                case '\n':
+                  if (p.hrChars < 3) break;
+                  endTokensToIndent(p, p.indentLen);
+                  p.renderer.addToken(p.renderer.data, RULE);
+                  p.renderer.endToken(p.renderer.data);
+                  clearRootPending(p);
+                  p.hrChars = 0;
+                  continue;
+              }
+
+              p.hrChars = 0;
+            }
+
+            /* Unordered list
+                /  * foo
+                /  * *bar*
+                /  * **baz**
+                /*/
+            if ('_' !== p.pending[0] && ' ' === p.pending[1]) {
+              continueOrAddList(p, LIST_UNORDERED);
+              addListItem(p, 2);
+              parserWrite(p, pendingWithChar.slice(2));
+              continue;
+            }
+
+            break; // fail
+          /* Code Fence */
+          case '`':
+          /*  FIX: CommonMark also fences with tildes; upstream only handled
+                backticks, so ~~~js turned into mangled strikethrough. Two
+                tildes followed by anything but a third still fail out below
+                and are re-dispatched as ~~strikethrough~~.
+            */
+          case '~': {
+            const fenceChar = p.pending[0];
+            /*  ``?
+                      ^
+                */
+            if (p.pending.length < 3) {
+              if (fenceChar === char) {
+                p.pending = pendingWithChar;
+                p.fenceStart = pendingWithChar.length;
+                continue;
+              }
+              p.fenceStart = 0;
+              break; // fail
+            }
+
+            if (fenceChar === char) {
+              /*  ````?
+                           ^
+                    */
+              if (p.pending.length === p.fenceStart) {
+                p.pending = pendingWithChar;
+                p.fenceStart = pendingWithChar.length;
+              }
+              /*  ```code`
+                               ^
+                    */
+              else {
+                addToken(p, PARAGRAPH);
+                clearRootPending(p);
+                p.fenceStart = 0;
+                parserWrite(p, pendingWithChar);
+              }
+              continue;
+            }
+
+            if ('\n' === char) {
+              /*  ```lang\n
+                                ^
+                    */
+              endTokensToIndent(p, p.indentLen);
+
+              addToken(p, CODE_FENCE);
+              p.fenceChar = fenceChar;
+              if (p.pending.length > p.fenceStart) {
+                /*  FIX: emit the class a syntax highlighter looks for,
+                    rather than the bare language name.
+                */
+                p.renderer.setAttr(
+                  p.renderer.data,
+                  LANG,
+                  `language-${p.pending.slice(p.fenceStart)}`
+                );
+              }
+              clearRootPending(p);
+              p.token = NEWLINE;
+              continue;
+            }
+
+            /*  ```lang\n
+                        ^
+                */
+            p.pending = pendingWithChar;
+            continue;
+          }
+          /*
+            List Unordered for '+'
+            The other list types are handled with HORIZONTAL_RULE
+            */
+          case '+':
+            if (' ' !== char) break; // fail
+
+            continueOrAddList(p, LIST_UNORDERED);
+            addListItem(p, 2);
+            continue;
+          /* List Ordered */
+          case '0':
+          case '1':
+          case '2':
+          case '3':
+          case '4':
+          case '5':
+          case '6':
+          case '7':
+          case '8':
+          case '9':
+            /*
+                12. foo
+                   ^
+                */
+            if ('.' === p.pending[p.pending.length - 1]) {
+              if (' ' !== char) break; // fail
+
+              if (continueOrAddList(p, LIST_ORDERED) && p.pending !== '1.') {
+                p.renderer.setAttr(
+                  p.renderer.data,
+                  START,
+                  p.pending.slice(0, -1)
+                );
+              }
+              addListItem(p, p.pending.length + 1);
+              continue;
+            } else {
+              const charCode = char.charCodeAt(0);
+              if (
+                46 === charCode || // '.'
+                isDigit(charCode) // 0-9
+              ) {
+                p.pending = pendingWithChar;
+                continue;
+              }
+            }
+            break; // fail
+          /* Table */
+          case '|':
+            endTokensToLen(p, p.blockquoteIdx);
+
+            addToken(p, TABLE);
+            addToken(p, TABLE_ROW);
+
+            p.pending = '';
+            parserWrite(p, char);
+
+            continue;
+        }
+
+        let toWrite = pendingWithChar;
+
+        /* Add a line break and continue in previous token */
+        if (p.token === LINE_BREAK) {
+          p.token = p.tokens[p.len];
+          p.renderer.addToken(p.renderer.data, LINE_BREAK);
+          p.renderer.endToken(p.renderer.data);
+        }
+        /* Code Block */
+        else if (p.indentLen >= 4) {
+          /*
+                Case where there are additional spaces
+                after the indent that makes the code block
+                _________________________
+                       code
+                ^^^^----indent
+                    ^^^-part of code
+                _________________________
+                 \t   code
+                ^^-----indent
+                   ^^^-part of code
+                */
+          let codeStart = 0;
+          for (; codeStart < 4; codeStart += 1) {
+            if (p.indent[codeStart] === '\t') {
+              codeStart = codeStart + 1;
+              break;
+            }
+          }
+          toWrite = p.indent.slice(codeStart) + pendingWithChar;
+          addToken(p, CODE_BLOCK);
+        }
+        /* Paragraph */
+        else {
+          addToken(p, PARAGRAPH);
+        }
+
+        clearRootPending(p);
+        parserWrite(p, toWrite);
+        continue;
+      case TABLE:
+        if (p.tableState === 1) {
+          switch (char) {
+            case '-':
+            case ' ':
+            case '|':
+            case ':':
+              p.pending = pendingWithChar;
+              continue;
+            case '\n':
+              p.tableState = 2;
+              p.pending = '';
+              continue;
+            default:
+              endToken(p);
+              p.tableState = 0;
+              break;
+          }
+        } else {
+          switch (p.pending) {
+            case '|':
+              addToken(p, TABLE_ROW);
+              p.pending = '';
+              parserWrite(p, char);
+              continue;
+            case '\n':
+              endToken(p);
+              p.pending = '';
+              p.tableState = 0;
+              parserWrite(p, char);
+              continue;
+          }
+        }
+        break;
+      case TABLE_ROW:
+        switch (p.pending) {
+          case '':
+            break;
+          case '|':
+            addToken(p, TABLE_CELL);
+            endToken(p);
+            p.pending = '';
+            parserWrite(p, char);
+            continue;
+          case '\n':
+            endToken(p);
+            p.tableState = Math.min(p.tableState + 1, 2);
+            p.pending = '';
+            parserWrite(p, char);
+            continue;
+          default:
+            addToken(p, TABLE_CELL);
+            parserWrite(p, char);
+            continue;
+        }
+        break;
+      case TABLE_CELL:
+        if (p.pending === '|') {
+          addText(p);
+          endToken(p);
+          p.pending = '';
+          parserWrite(p, char);
+          continue;
+        }
+        break;
+      case CODE_BLOCK:
+        switch (pendingWithChar) {
+          case '\n    ':
+          case '\n   \t':
+          case '\n  \t':
+          case '\n \t':
+          case '\n\t':
+            p.text += '\n';
+            p.pending = '';
+            continue;
+          case '\n':
+          case '\n ':
+          case '\n  ':
+          case '\n   ':
+            p.pending = pendingWithChar;
+            continue;
+          default:
+            if (p.pending.length !== 0) {
+              addText(p);
+              endToken(p);
+              p.pending = char;
+            } else {
+              p.text += char;
+            }
+            continue;
+        }
+      case CODE_FENCE:
+        /*  FIX: close on the character that opened the fence, not always
+                a backtick.
+            */
+        if (char === p.fenceChar) {
+          /*  ```\n<code>\n``??
+                |                 ^
+                */
+          p.pending = pendingWithChar;
+          continue;
+        }
+        switch (char) {
+          case '\n':
+            /*  ```\n<code>\n```\n
+                |                    ^
+                */
+            if (pendingWithChar.length === p.fenceStart + p.fenceEnd + 1) {
+              addText(p);
+              endToken(p);
+              p.pending = '';
+              p.fenceStart = 0;
+              p.fenceEnd = 0;
+              p.fenceChar = '';
+              p.token = NEWLINE;
+              continue;
+            }
+            p.token = NEWLINE;
+            break;
+          case ' ':
+            /*  ```\n<code>\n ??
+                |                ^  (space after newline is allowed)
+                */
+            if (p.pending[0] === '\n') {
+              p.pending = pendingWithChar;
+              p.fenceEnd += 1;
+              continue;
+            }
+            break;
+        }
+        // any other char
+        p.text += p.pending;
+        p.pending = char;
+        p.fenceEnd = 1;
+        continue;
+      case CODE_INLINE:
+        switch (char) {
+          case '`':
+            if (
+              pendingWithChar.length ===
+              p.fenceStart + Number(p.pending[0] === ' ') // 0 or 1 for space
+            ) {
+              addText(p);
+              endToken(p);
+              p.pending = '';
+              p.fenceStart = 0;
+            } else {
+              p.pending = pendingWithChar;
+            }
+            continue;
+          case '\n':
+            p.text += p.pending;
+            p.pending = '';
+            p.token = LINE_BREAK;
+            p.blockquoteIdx = 0;
+            addText(p);
+            continue;
+          /* Trim space before ` */
+          case ' ':
+            p.text += p.pending;
+            p.pending = char;
+            continue;
+          default:
+            p.text += pendingWithChar;
+            p.pending = '';
+            continue;
+        }
+      /* Checkboxes */
+      case MAYBE_TASK:
+        switch (p.pending.length) {
+          case 0:
+            if ('[' !== char) break; // fail
+            p.pending = pendingWithChar;
+            continue;
+          case 1:
+            if (' ' !== char && 'x' !== char) break; // fail
+            p.pending = pendingWithChar;
+            continue;
+          case 2:
+            if (']' !== char) break; // fail
+            p.pending = pendingWithChar;
+            continue;
+          case 3:
+            if (' ' !== char) break; // fail
+            p.renderer.addToken(p.renderer.data, CHECKBOX);
+            if ('x' === p.pending[1]) {
+              p.renderer.setAttr(p.renderer.data, CHECKED, '');
+            }
+            p.renderer.endToken(p.renderer.data);
+            p.pending = ' ';
+            continue;
+        }
+
+        p.token = p.tokens[p.len];
+        p.pending = '';
+        parserWrite(p, pendingWithChar);
+        continue;
+      case STRONG_AST:
+      case STRONG_UND: {
+        /** @type {string} */ let symbol = '*';
+        /** @type {Token } */ let italic = ITALIC_AST;
+        if (p.token === STRONG_UND) {
+          symbol = '_';
+          italic = ITALIC_UND;
+        }
+
+        if (symbol === p.pending) {
+          addText(p);
+          /* **Bold**
+                          ^
+                */
+          if (symbol === char) {
+            endToken(p);
+            p.pending = '';
+            continue;
+          }
+          /* **Bold*Bold->Em*
+                          ^
+                */
+          addToken(p, italic);
+          p.pending = char;
+          continue;
+        }
+
+        break;
+      }
+      case ITALIC_AST:
+      case ITALIC_UND: {
+        /** @type {string} */ let symbol = '*';
+        /** @type {Token } */ let strong = STRONG_AST;
+        if (p.token === ITALIC_UND) {
+          symbol = '_';
+          strong = STRONG_UND;
+        }
+
+        switch (p.pending) {
+          case symbol:
+            if (symbol === char) {
+              /* Decide between ***bold>em**em* and **bold*bold>em***
+                                                 ^                       ^
+                       With the help of the next character
+                    */
+              if (p.tokens[p.len - 1] === strong) {
+                p.pending = pendingWithChar;
+              }
+              /* *em**bold
+                           ^
+                    */
+              else {
+                addText(p);
+                addToken(p, strong);
+                p.pending = '';
+              }
+            }
+            /* *em*foo
+                       ^
+                */
+            else {
+              addText(p);
+              endToken(p);
+              p.pending = char;
+            }
+            continue;
+          case symbol + symbol:
+            const italic = p.token;
+            addText(p);
+            endToken(p);
+            endToken(p);
+            /* ***bold>em**em* or **bold*bold>em***
+                               ^                      ^
+                */
+            if (symbol !== char) {
+              addToken(p, italic);
+              p.pending = char;
+            } else {
+              p.pending = '';
+            }
+            continue;
+        }
+        break;
+      }
+      case STRIKE:
+        if ('~~' === pendingWithChar) {
+          addText(p);
+          endToken(p);
+          p.pending = '';
+          continue;
+        }
+        break;
+      case MAYBE_EQ_BLOCK:
+        /*
+             \[?  or  $$?
+               ^        ^
+            */
+        if (char === '\n') {
+          addText(p);
+          addToken(p, EQUATION_BLOCK);
+          p.pending = '';
+        } else {
+          p.token = p.tokens[p.len];
+          if (p.pending[0] === '\\') {
+            p.text += '[';
+          } else {
+            p.text += '$$';
+          }
+          p.pending = '';
+          parserWrite(p, char);
+        }
+        continue;
+      case EQUATION_BLOCK:
+        if ('\\]' === pendingWithChar || '$$' === pendingWithChar) {
+          addText(p);
+          endToken(p);
+          p.pending = '';
+          continue;
+        }
+        break;
+      case EQUATION_INLINE:
+        if ('\\)' === pendingWithChar || '$' === p.pending[0]) {
+          addText(p);
+          endToken(p);
+
+          if (char === ')') {
+            p.pending = '';
+          } else {
+            p.pending = char;
+          }
+          continue;
+        }
+        break;
+      /* Raw URLs */
+      case MAYBE_URL:
+        if ('http://' === pendingWithChar || 'https://' === pendingWithChar) {
+          addText(p);
+          addToken(p, RAW_URL);
+          p.pending = pendingWithChar;
+          p.text = pendingWithChar;
+        } else if (
+          'http:/'[p.pending.length] === char ||
+          'https:/'[p.pending.length] === char
+        ) {
+          p.pending = pendingWithChar;
+        } else {
+          p.token = p.tokens[p.len];
+          parserWrite(p, char);
+        }
+        continue;
+      case LINK:
+      case IMAGE:
+        if (']' === p.pending) {
+          /*
+                [Link](url)
+                     ^
+                */
+          addText(p);
+          if ('(' === char) {
+            p.pending = pendingWithChar;
+          } else {
+            endToken(p);
+            p.pending = char;
+          }
+          continue;
+        }
+        if (']' === p.pending[0] && '(' === p.pending[1]) {
+          /*
+                [Link](url)
+                          ^
+                */
+          if (')' === char) {
+            const type = p.token === LINK ? HREF : SRC;
+            /*  FIX: `[t](url "Title")` carries a title after the destination.
+                Upstream handed the whole thing over as the URL, which broke
+                the link.
+            */
+            if (p.token === IMAGE && p.altText !== '') {
+              p.renderer.setAttr(p.renderer.data, ALT, p.altText);
+              p.altText = '';
+            }
+            const destination = p.pending.slice(2);
+            const titled = /^(.*?)\s+(?:"([^"]*)"|'([^']*)')$/.exec(
+              destination
+            );
+            p.renderer.setAttr(
+              p.renderer.data,
+              type,
+              titled ? titled[1] : destination
+            );
+            if (titled) {
+              p.renderer.setAttr(
+                p.renderer.data,
+                TITLE,
+                titled[2] ?? titled[3]
+              );
+            }
+            endToken(p);
+            p.pending = '';
+          } else {
+            p.pending += char;
+          }
+          continue;
+        }
+        break;
+      case RAW_URL:
+        /* http://example.com?
+                                 ^
+            */
+        if (' ' === char || '\n' === char || '\\' === char) {
+          p.renderer.setAttr(p.renderer.data, HREF, p.pending);
+          addText(p);
+          endToken(p);
+          p.pending = char;
+        } else {
+          p.text += char;
+          p.pending = pendingWithChar;
+        }
+        continue;
+      case MAYBE_BR:
+        if (pendingWithChar.startsWith('<br')) {
+          if (
+            /* "<br" */
+            pendingWithChar.length === 3 ||
+            /* "<br " */
+            char === ' ' ||
+            /* "<br/" | "<br /" */
+            (char === '/' &&
+              (pendingWithChar.length === 4 ||
+                p.pending[p.pending.length - 1] === ' '))
+          ) {
+            p.pending = pendingWithChar;
+            continue;
+          }
+
+          /* "<br>" | "<br/>" */
+          if (char === '>') {
+            addText(p);
+            p.token = p.tokens[p.len];
+            p.renderer.addToken(p.renderer.data, LINE_BREAK);
+            p.renderer.endToken(p.renderer.data);
+            p.pending = '';
+            continue;
+          }
+        }
+        // Fail
+        p.token = p.tokens[p.len];
+        p.text += '<';
+        p.pending = p.pending.slice(1);
+        parserWrite(p, char);
+        continue;
+    }
+
+    /*
+        Common checks
+        */
+    switch (p.pending[0]) {
+      /* Escape character */
+      case '\\':
+        if (
+          p.token === IMAGE ||
+          p.token === EQUATION_BLOCK ||
+          p.token === EQUATION_INLINE
+        )
+          break;
+
+        switch (char) {
+          case '(':
+            addText(p);
+            addToken(p, EQUATION_INLINE);
+            p.pending = '';
+            continue;
+          case '[':
+            p.token = MAYBE_EQ_BLOCK;
+            p.pending = pendingWithChar;
+            continue;
+          case '\n':
+            // Escaped newline has the same affect as unescaped one
+            p.pending = char;
+            continue;
+          default:
+            let charcode = char.charCodeAt(0);
+            p.pending = '';
+            p.text +=
+              isDigit(charcode) || // 0-9
+              (charcode >= 65 && charcode <= 90) || // A-Z
+              (charcode >= 97 && charcode <= 122) // a-z
+                ? pendingWithChar
+                : char;
+            continue;
+        }
+      /* Newline */
+      case '\n':
+        switch (p.token) {
+          case IMAGE:
+          case EQUATION_BLOCK:
+          case EQUATION_INLINE:
+            break;
+          case HEADING_1:
+          case HEADING_2:
+          case HEADING_3:
+          case HEADING_4:
+          case HEADING_5:
+          case HEADING_6:
+            addText(p);
+            endTokensToLen(p, p.blockquoteIdx);
+            p.blockquoteIdx = 0;
+            p.pending = char;
+            continue;
+          default:
+            addText(p);
+            p.pending = char;
+            p.token = LINE_BREAK;
+            p.blockquoteIdx = 0;
+            continue;
+        }
+        break;
+      /* <br> */
+      case '<':
+        if (
+          p.token !== IMAGE &&
+          p.token !== EQUATION_BLOCK &&
+          p.token !== EQUATION_INLINE
+        ) {
+          addText(p);
+          p.pending = pendingWithChar;
+          p.token = MAYBE_BR;
+          continue;
+        }
+        break;
+      /* `Code Inline` */
+      case '`':
+        if (p.token === IMAGE) break;
+
+        if ('`' === char) {
+          p.fenceStart += 1;
+          p.pending = pendingWithChar;
+        } else {
+          p.fenceStart += 1; // started at 0, and first wasn't counted
+          addText(p);
+          addToken(p, CODE_INLINE);
+          p.text = ' ' === char || '\n' === char ? '' : char; // trim leading space
+          p.pending = '';
+        }
+        continue;
+      case '_':
+      case '*': {
+        if (
+          p.token === IMAGE ||
+          p.token === EQUATION_BLOCK ||
+          p.token === EQUATION_INLINE ||
+          p.token === STRONG_AST
+        )
+          break;
+
+        /** @type {Token} */ let italic = ITALIC_AST;
+        /** @type {Token} */ let strong = STRONG_AST;
+        const symbol = p.pending[0];
+        if ('_' === symbol) {
+          italic = ITALIC_UND;
+          strong = STRONG_UND;
+          /*  FIX: CommonMark only lets `_` open emphasis at a word
+                    boundary, so identifiers keep their underscores:
+                    snake_case_word, MAX_BUFFER_SIZE, __name__ mid-word.
+                    `*` is unrestricted and keeps upstream's behaviour.
+                */
+          const prevChar =
+            p.text.length > 0 ? p.text[p.text.length - 1] : p.lastTextChar;
+          if (prevChar !== '' && isAlnum(prevChar.charCodeAt(0))) break;
+        }
+
+        if (p.pending.length === 1) {
+          /* **Strong**
+                    ^
+                */
+          if (symbol === char) {
+            p.pending = pendingWithChar;
+            continue;
+          }
+          /* *Em*
+                    ^
+                */
+          if (' ' !== char && '\n' !== char) {
+            addText(p);
+            addToken(p, italic);
+            p.pending = char;
+            continue;
+          }
+        } else {
+          /* ***Strong->Em***
+                     ^
+                */
+          if (symbol === char) {
+            addText(p);
+            addToken(p, strong);
+            addToken(p, italic);
+            p.pending = '';
+            continue;
+          }
+          /* **Strong**
+                     ^
+                */
+          if (' ' !== char && '\n' !== char) {
+            addText(p);
+            addToken(p, strong);
+            p.pending = char;
+            continue;
+          }
+        }
+
+        break;
+      }
+      case '~':
+        if (p.token !== IMAGE && p.token !== STRIKE) {
+          if ('~' === p.pending) {
+            /* ~~Strike~~
+                        ^
+                    */
+            if ('~' === char) {
+              p.pending = pendingWithChar;
+              continue;
+            }
+          } else {
+            /* ~~Strike~~
+                    |    ^
+                    */
+            if (' ' !== char && '\n' !== char) {
+              addText(p);
+              addToken(p, STRIKE);
+              p.pending = char;
+              continue;
+            }
+          }
+        }
+        break;
+      /* $eq$ | $$eq$$ */
+      case '$':
+        if (p.token !== IMAGE && p.token !== STRIKE && '$' === p.pending) {
+          /* $$EQUATION_BLOCK$$
+                    ^
+                */
+          if ('$' === char) {
+            p.token = MAYBE_EQ_BLOCK;
+            p.pending = pendingWithChar;
+            continue;
+          }
+          /* $123
+                    ^
+                */
+          else if (isDelimeterOrNumber(char.charCodeAt(0))) {
+            break;
+          }
+          /* $EQUATION_INLINE$
+                    ^
+                */
+          else {
+            addText(p);
+            addToken(p, EQUATION_INLINE);
+            p.pending = char;
+            continue;
+          }
+        }
+        break;
+      /* [Image](url) */
+      case '[':
+        if (
+          p.token !== IMAGE &&
+          p.token !== LINK &&
+          p.token !== EQUATION_BLOCK &&
+          p.token !== EQUATION_INLINE &&
+          ']' !== char
+        ) {
+          addText(p);
+          addToken(p, LINK);
+          p.pending = char;
+          continue;
+        }
+        break;
+      /* ![Image](url) */
+      case '!':
+        if (!(p.token === IMAGE) && '[' === char) {
+          addText(p);
+          addToken(p, IMAGE);
+          p.pending = '';
+          continue;
+        }
+        break;
+      /* Trim spaces */
+      case ' ':
+        if (p.pending.length === 1 && ' ' === char) {
+          continue;
+        }
+        break;
+    }
+
+    /* foo http://...
+        |      ^
+        */
+    if (
+      p.token !== IMAGE &&
+      p.token !== LINK &&
+      p.token !== EQUATION_BLOCK &&
+      p.token !== EQUATION_INLINE &&
+      'h' === char &&
+      (' ' === p.pending || '' === p.pending)
+    ) {
+      p.text += p.pending;
+      p.pending = char;
+
+      p.token = MAYBE_URL;
+      continue;
+    }
+
+    /*
+        No check hit
+        */
+    p.text += p.pending;
+    p.pending = char;
+  }
+
+  addText(p);
+}
+
+/**
+ * @template T
+ * @callback RendererAddToken
+ * @param   {T    } data
+ * @param   {Token} type
+ * @returns {void } */
+
+/**
+ * @template T
+ * @callback RendererEndToken
+ * @param   {T    } data
+ * @returns {void } */
+
+/**
+ * @template T
+ * @callback RendererAddText
+ * @param   {T     } data
+ * @param   {string} text
+ * @returns {void  } */
+
+/**
+ * @template T
+ * @callback RendererSetAttr
+ * @param   {T     } data
+ * @param   {Attr  } type
+ * @param   {string} value
+ * @returns {void  } */
+
+/**
+ * The renderer interface.
+ * @template T
+ * @typedef  {object               } Renderer
+ * @property {T                    } data      User data object. Available as first param in callbacks.
+ * @property {RendererAddToken<T>} addToken When the tokens starts.
+ * @property {RendererEndToken<T>} endToken When the token ends.
+ * @property {RendererAddText <T>} addText  To append text to current token. Can be called multiple times or none.
+ * @property {RendererSetAttr <T>} setAttr  Set additional attributes of current token eg. the link url.
+ */
+
+/** @typedef {Renderer<any>} AnyRenderer */

--- a/streaming-markdown-html/render-stream.js
+++ b/streaming-markdown-html/render-stream.js
@@ -1,0 +1,97 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/** Elements the HTML parser never gives children, so they never open a scope. */
+const VOID_ELEMENTS = new Set([
+  'area',
+  'base',
+  'br',
+  'col',
+  'embed',
+  'hr',
+  'img',
+  'input',
+  'link',
+  'meta',
+  'source',
+  'track',
+  'wbr',
+]);
+
+// Chunks are single tokens, so an opening tag is matched rather than parsed.
+// Attributes may be valueless: serializers differ on whether a boolean one
+// comes out as `checked` or `checked=""`.
+const OPEN_TAG = /^<([a-z0-9-]+)((?:\s+[a-z-]+(?:="[^"]*")?)*)\s*>$/i;
+const ATTRIBUTE = /([a-z-]+)(?:="([^"]*)")?/gi;
+
+function unescapeText(text) {
+  return text
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&amp;/g, '&');
+}
+
+/**
+ * A `WritableStream` that renders the HTML chunks from
+ * `createHtmlTokenStreamer()` into an element as they arrive.
+ *
+ * ```js
+ * await htmlChunkStream.pipeTo(renderStreamingHTML(output));
+ * ```
+ *
+ * Piping drains the stream, and brings the rest of the streams machinery with
+ * it: put a `TransformStream` in the middle to see the chunks on their way
+ * past.
+ *
+ * Nodes are built with `createElement` and `append`, never from a string, so
+ * this works on pages that enforce Trusted Types. That is why every chunk is a
+ * single token: a balanced fragment would need `insertAdjacentHTML`, which such
+ * pages refuse.
+ *
+ * @param {HTMLElement} element Where to render.
+ * @returns {WritableStream<string>}
+ */
+export function renderStreamingHTML(element) {
+  if (!element) {
+    throw new TypeError('renderStreamingHTML() requires an element.');
+  }
+  // The open elements, innermost last, exactly as the parser would track them.
+  const open = [element];
+
+  return new WritableStream({
+    write(chunk) {
+      const cursor = open.at(-1);
+
+      if (chunk.startsWith('</')) {
+        if (open.length > 1) {
+          open.pop();
+        }
+        return;
+      }
+
+      if (chunk.startsWith('<')) {
+        const tag = OPEN_TAG.exec(chunk);
+        if (!tag) {
+          throw new TypeError(`Not a single HTML token: ${chunk}`);
+        }
+        const child = document.createElement(tag[1]);
+        for (const [, name, value] of tag[2].matchAll(ATTRIBUTE)) {
+          child.setAttribute(
+            name,
+            value === undefined ? '' : unescapeText(value)
+          );
+        }
+        cursor.append(child);
+        if (!VOID_ELEMENTS.has(child.localName)) {
+          open.push(child);
+        }
+        return;
+      }
+
+      cursor.append(unescapeText(chunk));
+    },
+  });
+}

--- a/streaming-markdown-html/renderer.js
+++ b/streaming-markdown-html/renderer.js
@@ -1,0 +1,275 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as smd from './parser.js';
+import { isSafeUrl } from './safe-url.js';
+
+/** Escapes a text node the way the HTML serializer would. */
+function escapeText(text) {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
+/**
+ * Serializes an element's opening tag, and reports whether it's void.
+ *
+ * Cloning without children and trimming the closing tag off the serialization
+ * means attribute quoting and escaping come from the browser's own serializer
+ * rather than from string concatenation here.
+ */
+function tagsOf(element) {
+  const html = element.cloneNode(false).outerHTML;
+  const close = `</${element.localName}>`;
+  return html.endsWith(close)
+    ? { open: html.slice(0, -close.length), close }
+    : { open: html, close: '' };
+}
+
+/**
+ * Streams Markdown into HTML at the granularity the parser works at: an
+ * opening tag, a run of text, a closing tag.
+ *
+ * A chunk is therefore *not* a balanced fragment — `<p>` arrives before the
+ * text inside it, and `</p>` long after. Concatenating every chunk yields the
+ * complete, well-formed HTML. To put it on screen as it arrives, pipe those
+ * chunks into `renderStreamingHTML()`.
+ *
+ * Safety comes from construction rather than from a post-hoc scrub: every tag
+ * is one the Markdown parser picked from a fixed set, all text is escaped, and
+ * `href`/`src` values are scheme-checked before they're set. The model's raw
+ * Markdown is separately sanitized with the Sanitizer API by the caller.
+ *
+ * @param {object} options
+ * @param {(html: string) => void} [options.onHtml] Receives each HTML chunk.
+ * @param {(detail: {attribute: string, value: string}) => void} [options.onUnsafe]
+ */
+export function createHtmlTokenStreamer({ onHtml, onUnsafe } = {}) {
+  // The nodes exist only to be serialized, so they are built in a document with
+  // no browsing context: an image URL the model made up is never requested.
+  const doc = document.implementation.createHTMLDocument('');
+  const root = doc.createElement('div');
+
+  // Markdown puts a link's URL after its text — `[docs](url)` — so smd sets
+  // `href` and `src` only when the token closes, long after the opening tag
+  // would have been emitted. For these, hold everything back and emit the
+  // finished element in one piece. They're small, so nothing visibly stalls.
+  const LATE_ATTRIBUTE_TOKENS = new Set([
+    smd.LINK,
+    smd.RAW_URL,
+    smd.IMAGE,
+    smd.CHECKBOX,
+  ]);
+  let bufferDepth = 0;
+  let bufferRoot = null;
+
+  const emit = (html) => {
+    if (html && bufferDepth === 0) {
+      onHtml?.(html);
+    }
+  };
+
+  /**
+   * Emits a finished element as the same opening tag / text / closing tag
+   * chunks the streaming path produces, rather than as one balanced fragment.
+   *
+   * Concatenated the result is identical either way, but keeping every chunk to
+   * a single token means a consumer can rebuild the DOM with `createElement`
+   * and `append` alone. Handing it a fragment would force `insertAdjacentHTML`,
+   * which pages that enforce Trusted Types refuse.
+   */
+  const emitElement = (node) => {
+    if (node.nodeType === 3) {
+      onHtml?.(escapeText(node.data));
+      return;
+    }
+    const { open, close } = tagsOf(node);
+    onHtml?.(open);
+    for (const child of node.childNodes) {
+      emitElement(child);
+    }
+    if (close) {
+      onHtml?.(close);
+    }
+  };
+
+  // One frame per open token. The `elements` array holds what the token
+  // opened, outermost first. The `deferred` entry holds an element opened by a
+  // descendant whose closing tag belongs to this token instead, such as a
+  // `<tbody>` spanning rows.
+  const frames = [];
+  // The opening tags of the most recent token, not yet serialized: setAttr()
+  // runs after addToken(), and the attributes have to be in the tag.
+  let pendingFrame = null;
+
+  const flush = () => {
+    if (!pendingFrame) {
+      return;
+    }
+    for (const element of pendingFrame.elements) {
+      const { open, close } = tagsOf(element);
+      pendingFrame.closers.push(close);
+      emit(open);
+    }
+    pendingFrame = null;
+  };
+
+  const closeFrame = (frame) => {
+    // A deferred tag (a <tbody> spanning rows) sits inside this frame's own
+    // element, so it closes first.
+    for (const close of [...frame.deferred].reverse()) {
+      emit(close);
+    }
+    for (const close of [...frame.closers].reverse()) {
+      emit(close);
+    }
+  };
+
+  const data = { nodes: [root], index: 0 };
+
+  function appendText(element, text) {
+    element.appendChild(doc.createTextNode(text));
+    emit(escapeText(text));
+  }
+
+  const renderer = {
+    data,
+
+    addToken(data, type) {
+      if (type === smd.DOCUMENT) {
+        return;
+      }
+      flush();
+
+      let parent = data.nodes[data.index];
+      const opened = [];
+      const create = (tag) => doc.createElement(tag);
+
+      // The parser names the elements; only the table's structure depends on
+      // where in the table the token landed, so that stays here.
+      const tags = smd.tokenToTags(type);
+      let slot;
+
+      switch (type) {
+        case smd.CHECKBOX:
+          slot = create('input');
+          slot.setAttribute('type', 'checkbox');
+          slot.setAttribute('disabled', '');
+          break;
+        case smd.CODE_BLOCK:
+        case smd.CODE_FENCE:
+          parent = parent.appendChild(create(tags[0]));
+          opened.push(parent);
+          slot = create(tags[1]);
+          break;
+        case smd.TABLE_ROW: {
+          // The first row makes a <thead>, the second a <tbody>, and rows after
+          // that reuse the <tbody> — so the <tbody> outlives its row and is
+          // closed by the <table> frame instead.
+          if (parent.children.length === 0) {
+            parent = parent.appendChild(create('thead'));
+            opened.push(parent);
+          } else if (parent.children.length === 1) {
+            const tbody = parent.appendChild(create('tbody'));
+            const { open, close } = tagsOf(tbody);
+            emit(open);
+            frames.at(-1)?.deferred.push(close);
+            parent = tbody;
+          } else {
+            parent = parent.children[1];
+          }
+          slot = create('tr');
+          break;
+        }
+        case smd.TABLE_CELL:
+          slot = create(
+            parent.parentElement?.tagName === 'THEAD' ? 'th' : 'td'
+          );
+          break;
+        default:
+          slot = create(tags[0]);
+      }
+
+      opened.push(parent.appendChild(slot));
+      data.nodes[++data.index] = slot;
+
+      const buffered = LATE_ATTRIBUTE_TOKENS.has(type);
+      if (buffered) {
+        if (bufferDepth === 0) {
+          bufferRoot = slot;
+        }
+        bufferDepth++;
+      }
+
+      pendingFrame = { elements: opened, closers: [], deferred: [], buffered };
+      frames.push(pendingFrame);
+    },
+
+    setAttr(data, type, value) {
+      const attribute = smd.attrToHtmlAttr(type);
+      const element = data.nodes[data.index];
+
+      // The only values the model controls that reach an attribute.
+      if ((attribute === 'href' || attribute === 'src') && !isSafeUrl(value)) {
+        onUnsafe?.({ attribute, value });
+        return;
+      }
+
+      element.setAttribute(attribute, value);
+    },
+
+    addText(data, text) {
+      flush();
+      appendText(data.nodes[data.index], text);
+    },
+
+    endToken(data) {
+      flush();
+      data.index -= 1;
+      const frame = frames.pop();
+      if (!frame) {
+        return;
+      }
+      if (frame.buffered) {
+        bufferDepth--;
+        if (bufferDepth === 0) {
+          const element = bufferRoot;
+          bufferRoot = null;
+          emitElement(element);
+        }
+        return;
+      }
+      closeFrame(frame);
+    },
+  };
+
+  const parser = smd.parser(renderer);
+
+  return {
+    /** @param {string} chunk Markdown, in whatever pieces it arrives. */
+    write(chunk) {
+      smd.parserWrite(parser, chunk);
+    },
+    /** Flushes the parser and closes any tags Markdown left open. */
+    end() {
+      smd.parserEnd(parser);
+      flush();
+      while (frames.length > 0) {
+        const frame = frames.pop();
+        if (frame.buffered) {
+          bufferDepth--;
+          if (bufferDepth === 0) {
+            const element = bufferRoot;
+            bufferRoot = null;
+            emitElement(element);
+          }
+          continue;
+        }
+        closeFrame(frame);
+      }
+    },
+  };
+}

--- a/streaming-markdown-html/safe-url.js
+++ b/streaming-markdown-html/safe-url.js
@@ -1,0 +1,43 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * URL schemes that are safe to keep in `href` and `src`. The Sanitizer API's
+ * default configuration removes unsafe *elements and attributes*, but it
+ * deliberately doesn't filter URL schemes, so `[x](javascript:alert(1))` would
+ * survive. This closes that gap.
+ */
+const SAFE_URL_SCHEMES = new Set([
+  'http:',
+  'https:',
+  'mailto:',
+  'tel:',
+  'sms:',
+  'ftp:',
+]);
+
+const SAFE_DATA_URL = /^data:image\/(?:png|jpeg|gif|webp|avif)[;,]/i;
+
+/**
+ * @param {string} value A URL, absolute or relative.
+ * @returns {boolean} Whether it is safe to put in an `href` or `src`.
+ */
+export function isSafeUrl(value) {
+  const trimmed = value.trim();
+  // Empty, fragment-only, and root/query-relative URLs can't carry a scheme.
+  if (trimmed === '' || /^[#/?]/.test(trimmed)) {
+    return true;
+  }
+  let url;
+  try {
+    url = new URL(trimmed, document.baseURI);
+  } catch {
+    return false;
+  }
+  if (SAFE_URL_SCHEMES.has(url.protocol)) {
+    return true;
+  }
+  return url.protocol === 'data:' && SAFE_DATA_URL.test(trimmed);
+}

--- a/streaming-markdown-html/test/dom.js
+++ b/streaming-markdown-html/test/dom.js
@@ -1,0 +1,50 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// A DOM for Node, so the real renderer can be tested rather than a stand-in.
+import { parseHTML } from 'linkedom';
+
+const { document, Element, Node, Event, CustomEvent } = parseHTML(
+  '<!doctype html><html><body></body></html>'
+);
+
+// linkedom's dispatchEvent writes to fields that Node's built-in Event exposes
+// as read-only getters, so tests that dispatch on this document need linkedom's
+// own Event class.
+export { Event as DomEvent };
+
+globalThis.document = document;
+globalThis.Element = Element;
+globalThis.Node = Node;
+globalThis.CustomEvent ??= CustomEvent;
+
+// linkedom has no `document.implementation`; the renderer builds into an inert
+// document when it isn't given a target element.
+if (!document.implementation) {
+  Object.defineProperty(document, 'implementation', {
+    value: {
+      createHTMLDocument: () =>
+        parseHTML('<!doctype html><html><body></body></html>').document,
+    },
+    configurable: true,
+  });
+}
+
+// linkedom has no setHTML(); the renderer uses it to resolve entity references
+// because innerHTML is refused on pages that enforce Trusted Types. linkedom's
+// innerHTML resolves them, so it stands in here.
+if (typeof Element.prototype.setHTML !== 'function') {
+  Element.prototype.setHTML = function setHTML(html) {
+    this.innerHTML = html;
+  };
+}
+
+// `isSafeUrl()` resolves relative URLs against the document base.
+if (!document.baseURI) {
+  Object.defineProperty(document, 'baseURI', {
+    value: 'https://example.test/',
+    configurable: true,
+  });
+}

--- a/streaming-markdown-html/test/markdown-to-html.test.js
+++ b/streaming-markdown-html/test/markdown-to-html.test.js
@@ -1,0 +1,95 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import './dom.js';
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { createHtmlTokenStreamer } from '../renderer.js';
+import { markdownToHtml } from '../markdown-to-html.js';
+import { renderStreamingHTML } from '../render-stream.js';
+import { normalizeHtml } from './normalize.js';
+
+/** Feeds `chunks` through a stream and collects what comes out. */
+async function through(chunks, options) {
+  const source = new ReadableStream({
+    start(controller) {
+      for (const chunk of chunks) {
+        controller.enqueue(chunk);
+      }
+      controller.close();
+    },
+  });
+  const out = [];
+  await source
+    .pipeThrough(markdownToHtml(options))
+    .pipeTo(new WritableStream({ write: (html) => void out.push(html) }));
+  return out;
+}
+
+const SAMPLE = [
+  '# Title\n\nAT&a',
+  'mp;T wrote `x & y`.\n\n',
+  '| a ',
+  '| b |\n| - | - |\n|  c  |  d  |\n\n',
+  '~~gone~~ and [t](https://x.test "Ti")\n',
+];
+
+describe('markdownToHtml', () => {
+  it('emits the same chunks as the callback API', async () => {
+    const expected = [];
+    const streamer = createHtmlTokenStreamer({
+      onHtml: (html) => expected.push(html),
+    });
+    for (const chunk of SAMPLE) {
+      streamer.write(chunk);
+    }
+    streamer.end();
+
+    assert.deepEqual(await through(SAMPLE), expected);
+  });
+
+  it('closes tags the Markdown left open, on flush', async () => {
+    // No trailing newline, so the paragraph is still open when input ends.
+    const out = await through(['*hi*']);
+    assert.equal(out.join(''), '<p><em>hi</em></p>');
+  });
+
+  it('pipes into renderStreamingHTML', async () => {
+    const root = document.createElement('div');
+    const source = new ReadableStream({
+      start(controller) {
+        for (const chunk of SAMPLE) {
+          controller.enqueue(chunk);
+        }
+        controller.close();
+      },
+    });
+    await source
+      .pipeThrough(markdownToHtml())
+      .pipeTo(renderStreamingHTML(root));
+
+    // Attribute order differs between the two, and means nothing in HTML.
+    assert.equal(
+      normalizeHtml(root.innerHTML),
+      normalizeHtml((await through(SAMPLE)).join(''))
+    );
+    assert.match(root.innerHTML, /<h1>Title<\/h1>/);
+    // The entity was split across two chunks and still resolved.
+    assert.match(root.innerHTML, /AT&amp;T/);
+  });
+
+  it('reports an unsafe URL rather than emitting it', async () => {
+    const unsafe = [];
+    const out = await through(['[x](javascript:void0)\n'], {
+      onUnsafe: (detail) => unsafe.push(detail),
+    });
+    assert.deepEqual(unsafe, [
+      { attribute: 'href', value: 'javascript:void0' },
+    ]);
+    assert.ok(!out.join('').includes('javascript:'));
+  });
+});

--- a/streaming-markdown-html/test/markdown.test.js
+++ b/streaming-markdown-html/test/markdown.test.js
@@ -1,0 +1,255 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import './dom.js';
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { marked } from 'marked';
+
+import { createHtmlTokenStreamer } from '../renderer.js';
+import { renderStreamingHTML } from '../render-stream.js';
+import { normalizeHtml } from './normalize.js';
+
+marked.setOptions({ gfm: true, breaks: false });
+
+/** Runs Markdown through the streamer and returns the concatenated HTML. */
+function render(markdown, { chunkSize } = {}) {
+  const out = [];
+  const streamer = createHtmlTokenStreamer({
+    onHtml: (html) => out.push(html),
+  });
+  const chunks = chunkSize
+    ? (markdown.match(new RegExp(`[\\s\\S]{1,${chunkSize}}`, 'g')) ?? [])
+    : [markdown];
+  for (const chunk of chunks) {
+    streamer.write(chunk);
+  }
+  streamer.end();
+  return out.join('');
+}
+
+/**
+ * Asserts our output matches what a CommonMark + GFM parser produces, and that
+ * it does so however the input is chopped up. Chunk boundaries land in the
+ * middle of constructs when a model streams, so every case is also fed in
+ * small pieces.
+ */
+function matchesReference(markdown) {
+  const expected = normalizeHtml(marked.parse(markdown));
+  assert.equal(normalizeHtml(render(markdown)), expected, 'whole input');
+  for (const chunkSize of [1, 2, 3, 4, 7]) {
+    assert.equal(
+      normalizeHtml(render(markdown, { chunkSize })),
+      expected,
+      `chunk size ${chunkSize}`
+    );
+  }
+}
+
+// Constructs an LLM routinely emits. Each must match the reference parser.
+const CASES = {
+  'ATX heading': '# Title\n',
+  'bold and italic': 'a **b** and *c*\n',
+  'nested emphasis': '**bold with *italic* inside**\n',
+  'escaped asterisk': 'literal \\*not emphasis\\*\n',
+  'inline code': 'use `code` here\n',
+  'fenced code with language': '```js\nlet x = 1;\n```\n',
+  'tilde fence': '~~~js\nlet x = 1;\n~~~\n',
+  'fence containing backticks': '````\n```\n````\n',
+  'indented code': '    indented code\n',
+  'unordered list': '- a\n- b\n',
+  'ordered list': '1. a\n2. b\n',
+  'ordered list with start': '3. a\n4. b\n',
+  'nested list': '- a\n  - b\n',
+  'task list': '- [x] done\n- [ ] todo\n',
+  blockquote: '> quoted\n',
+  'nested blockquote': '> a\n> > b\n',
+  'blockquote with list': '> - a\n> - b\n',
+  'inline link': '[t](https://e.com/)\n',
+  'link with title': '[t](https://e.com/ "Title")\n',
+  'bare url': 'see https://e.com/ ok\n',
+  image: '![alt](https://e.com/i.png)\n',
+  'hard break with backslash': 'line one\\\nline two\n',
+  'thematic break': 'a\n\n---\n\nb\n',
+  table: '| a | b |\n| --- | --- |\n| 1 | 2 |\n',
+  strikethrough: '~~gone~~\n',
+  'html entity': 'AT&amp;T &copy; &#65;\n',
+  'consecutive emphasis': '*a* *b* *c*\n',
+  'intraword underscore': 'snake_case_word\n',
+  'dunder identifier': 'call __init__ here\n',
+  'constant with underscores': 'set MAX_BUFFER_SIZE now\n',
+  'underscore emphasis': 'an _emphasised_ word\n',
+  'underscore strong': 'an __important__ word\n',
+};
+
+describe('markdown to HTML', () => {
+  for (const [name, markdown] of Object.entries(CASES)) {
+    it(name, () => matchesReference(markdown));
+  }
+});
+
+// Two CommonMark constructs are deliberately not supported. These tests pin the
+// current behaviour so that a future fix shows up as a failure here rather than
+// as a silent change.
+describe('known deviations from CommonMark', () => {
+  it('does not support setext headings', () => {
+    // `Title` is emitted as a paragraph before the `=====` line is seen, and
+    // the parser never revises what it already emitted. Supporting this would
+    // mean holding every paragraph back by one line, which is the cost the
+    // append-only design exists to avoid. LLMs use ATX headings essentially
+    // always.
+    assert.equal(render('Title\n=====\n'), '<p>Title<br>=====</p>');
+  });
+
+  it('does not support angle-bracket autolinks', () => {
+    // `<https://e.com/>` stays literal. Making `<` open a link risks swallowing
+    // the `<placeholder>` style text that LLM prose is full of, and bare URLs
+    // and [text](url) links — which are what models actually emit — both work.
+    assert.equal(render('<https://e.com/>\n'), '<p>&lt;https://e.com/&gt;</p>');
+    assert.match(
+      render('see https://e.com/ ok\n'),
+      /<a href="https:\/\/e\.com\/">/
+    );
+  });
+
+  it('does not resolve reference links', () => {
+    // `[t][r]` needs the `[r]: url` definition, which may appear anywhere later
+    // in the document. Resolving it means a second pass over text already
+    // emitted, which an append-only parser cannot do. The anchors come out
+    // without an href, so they render as plain text rather than dead links.
+    assert.equal(
+      render('[t][r]\n\n[r]: https://e.com/\n'),
+      '<p><a>t</a><a>r</a></p>' +
+        '<p><a>r</a>: <a href="https://e.com/">https://e.com/</a></p>'
+    );
+  });
+
+  it('does not wrap loose list items in paragraphs', () => {
+    // Whether a list is loose is only known once the blank line after it is
+    // seen, by which point <li> and its text are already out. Affects spacing
+    // only.
+    assert.equal(render('- a\n\n- b\n'), '<ul><li>a</li><li>b</li></ul>');
+  });
+
+  it("does not keep a list item's second paragraph inside the item", () => {
+    assert.equal(
+      render('- para one\n\n  para two\n'),
+      '<ul><li>para one</li></ul><p>para two</p>'
+    );
+  });
+
+  it('does not parse block constructs inside list items', () => {
+    assert.equal(render('- # h\n'), '<ul><li># h</li></ul>');
+  });
+
+  it('ignores table column alignment', () => {
+    // The reference parser emits the deprecated `align` attribute, which
+    // sanitizers strip anyway.
+    assert.match(
+      render('| a | b |\n| :-- | --: |\n| 1 | 2 |\n'),
+      /<th>a<\/th><th>b<\/th>/
+    );
+  });
+
+  it('keeps the space before a two-space hard break', () => {
+    // Renders identically; the difference is only in the markup.
+    assert.equal(
+      render('line one  \nline two\n'),
+      '<p>line one <br>line two</p>'
+    );
+  });
+
+  it('leaves <placeholder> prose alone', () => {
+    assert.equal(
+      render('replace <your-key> with it\n'),
+      '<p>replace &lt;your-key&gt; with it</p>'
+    );
+  });
+});
+
+describe('streaming', () => {
+  const sample =
+    '# Title\n\nA **bold** para with `code` and a [link](https://e.com/).\n\n' +
+    '- one\n- two\n\n```js\nlet x = 1;\n```\n\n| a | b |\n| --- | --- |\n| 1 | 2 |\n';
+
+  it('output is independent of chunk size', () => {
+    const whole = render(sample);
+    for (const chunkSize of [1, 2, 3, 5, 7, 13, 64]) {
+      assert.equal(
+        render(sample, { chunkSize }),
+        whole,
+        `chunkSize ${chunkSize}`
+      );
+    }
+  });
+
+  it('emits far more chunks than blocks', () => {
+    const out = [];
+    const streamer = createHtmlTokenStreamer({ onHtml: (h) => out.push(h) });
+    streamer.write(sample);
+    streamer.end();
+    assert.ok(
+      out.length > 20,
+      `expected a token-level stream, got ${out.length}`
+    );
+  });
+
+  it('opens with a tag rather than a whole block', () => {
+    const out = [];
+    const streamer = createHtmlTokenStreamer({ onHtml: (h) => out.push(h) });
+    streamer.write('Hello world');
+    assert.equal(out[0], '<p>');
+  });
+
+  it('describes a DOM that can be rebuilt from the chunks alone', async () => {
+    const out = [];
+    const streamer = createHtmlTokenStreamer({ onHtml: (h) => out.push(h) });
+    streamer.write(sample);
+    streamer.end();
+
+    const rebuilt = document.createElement('div');
+    const writer = renderStreamingHTML(rebuilt).getWriter();
+    for (const html of out) {
+      await writer.write(html);
+    }
+    await writer.close();
+
+    assert.equal(normalizeHtml(rebuilt.innerHTML), normalizeHtml(out.join('')));
+  });
+});
+
+describe('untrusted content', () => {
+  it('escapes raw HTML into text', () => {
+    assert.equal(
+      render('<img src=x onerror=alert(1)>'),
+      '<p>&lt;img src=x onerror=alert(1)&gt;</p>'
+    );
+  });
+
+  it('reports a javascript: link and drops the href', () => {
+    const unsafe = [];
+    const out = [];
+    const streamer = createHtmlTokenStreamer({
+      onHtml: (h) => out.push(h),
+      onUnsafe: (d) => unsafe.push(d),
+    });
+    streamer.write('[click](javascript:alert(1))');
+    streamer.end();
+    assert.deepEqual(
+      unsafe.map((u) => u.attribute),
+      ['href']
+    );
+    assert.ok(!out.join('').includes('javascript:'));
+  });
+
+  it('keeps safe and relative urls', () => {
+    assert.equal(render('[x](/docs)'), '<p><a href="/docs">x</a></p>');
+    assert.equal(
+      render('[x](https://e.com/)'),
+      '<p><a href="https://e.com/">x</a></p>'
+    );
+  });
+});

--- a/streaming-markdown-html/test/normalize.js
+++ b/streaming-markdown-html/test/normalize.js
@@ -1,0 +1,32 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Normalizes HTML for comparison. Attribute order, insignificant whitespace
+ * between tags, and how an entity happens to be spelled (`&copy;` versus ©)
+ * carry no meaning, so none of them should count as a difference. Parsing and
+ * re-serializing settles the entity spelling.
+ */
+export function normalizeHtml(html) {
+  const probe = globalThis.document.createElement('div');
+  probe.innerHTML = html;
+  return probe.innerHTML
+    .replace(
+      /<([a-zA-Z][\w-]*)((?:\s+[\w:-]+(?:="[^"]*")?)*)\s*\/?>/g,
+      (_match, tag, attrs) => {
+        const list = [...attrs.matchAll(/([\w:-]+)(?:="([^"]*)")?/g)]
+          // `checked` and `checked=""` are the same attribute; serializers
+          // differ on which they write.
+          .map(([, name, value]) =>
+            value === undefined || value === '' ? name : `${name}="${value}"`
+          )
+          .sort();
+        return `<${tag}${list.length > 0 ? ` ${list.join(' ')}` : ''}>`;
+      }
+    )
+    .replace(/\n/g, '')
+    .replace(/>\s+</g, '><')
+    .trim();
+}

--- a/streaming-markdown-html/test/render-stream.test.js
+++ b/streaming-markdown-html/test/render-stream.test.js
@@ -1,0 +1,115 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import './dom.js';
+
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { describe, it } from 'node:test';
+
+import { createHtmlTokenStreamer } from '../renderer.js';
+import { renderStreamingHTML } from '../render-stream.js';
+import { normalizeHtml } from './normalize.js';
+
+/**
+ * Streams Markdown to HTML chunks, then rebuilds a DOM from those chunks.
+ *
+ * The chunks concatenated are the HTML the response describes, so rebuilding
+ * them and serializing has to come back to the same thing.
+ */
+async function bothWays(markdown, { chunkSize } = {}) {
+  const chunks = [];
+  const emitter = createHtmlTokenStreamer({ onHtml: (h) => chunks.push(h) });
+
+  const pieces = chunkSize
+    ? (markdown.match(new RegExp(`[\\s\\S]{1,${chunkSize}}`, 'g')) ?? [])
+    : [markdown];
+  for (const piece of pieces) {
+    emitter.write(piece);
+  }
+  emitter.end();
+
+  const piped = document.createElement('div');
+  const writer = renderStreamingHTML(piped).getWriter();
+  for (const chunk of chunks) {
+    await writer.write(chunk);
+  }
+  await writer.close();
+
+  // Attribute order carries no meaning and serializers disagree on it.
+  return {
+    chunks,
+    direct: normalizeHtml(chunks.join('')),
+    piped: normalizeHtml(piped.innerHTML),
+  };
+}
+
+const CASES = {
+  'heading and paragraph': '# Title\n\nA **bold** para.\n',
+  'inline code': 'use `code` here\n',
+  link: 'See [docs](https://e.com/a?b=1&c=2 "T") now.\n',
+  image: '![alt text](https://e.com/i.png)\n',
+  lists: '- one\n- two\n\n1. a\n2. b\n',
+  'nested list': '- outer\n  - inner\n',
+  'task list': '- [x] done\n- [ ] todo\n',
+  'fenced code': '```js\nlet x = 1 < 2 && 3 > 2;\n```\n',
+  blockquote: '> quoted **text**\n',
+  table: '| a | b |\n| --- | --- |\n| 1 | 2 |\n| 3 | 4 |\n',
+  entities: 'AT&amp;T &copy; 5 < 6\n',
+  'link with markup inside': '[**bold** link](https://e.com/)\n',
+  'thematic break': 'a\n\n---\n\nb\n',
+};
+
+describe('renderStreamingHTML', () => {
+  for (const [name, markdown] of Object.entries(CASES)) {
+    it(`rebuilds the HTML it was given: ${name}`, async () => {
+      const { direct, piped } = await bothWays(markdown);
+      assert.equal(piped, direct);
+    });
+  }
+
+  it('is unaffected by how the Markdown was chunked', async () => {
+    const markdown = Object.values(CASES).join('\n');
+    const whole = await bothWays(markdown);
+    for (const chunkSize of [1, 3, 7]) {
+      const split = await bothWays(markdown, { chunkSize });
+      assert.equal(split.piped, whole.piped, `chunk size ${chunkSize}`);
+    }
+  });
+
+  it('receives only single tokens, never a balanced fragment', async () => {
+    const { chunks } = await bothWays(Object.values(CASES).join('\n'));
+    for (const chunk of chunks) {
+      if (chunk.startsWith('<')) {
+        assert.equal(
+          chunk.indexOf('<', 1),
+          -1,
+          `fragment would need insertAdjacentHTML: ${chunk}`
+        );
+      }
+    }
+  });
+
+  // A page enforcing Trusted Types refuses every string-to-DOM sink, so the
+  // renderer must not reach for one.
+  it('never uses a string-to-DOM sink', () => {
+    const source = readFileSync(
+      new URL('../render-stream.js', import.meta.url),
+      'utf8'
+    );
+    for (const sink of [
+      'innerHTML',
+      'outerHTML',
+      'insertAdjacentHTML',
+      'document.write',
+    ]) {
+      assert.ok(!source.includes(`.${sink}`), `render-stream.js uses ${sink}`);
+    }
+  });
+
+  it('rejects an element-less call', () => {
+    assert.throws(() => renderStreamingHTML(), { name: 'TypeError' });
+  });
+});

--- a/streaming-markdown-html/tsconfig.json
+++ b/streaming-markdown-html/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": false,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "outDir": "types",
+    "target": "es2022",
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "lib": ["es2022", "dom"],
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": [
+    "index.js",
+    "parser.js",
+    "renderer.js",
+    "markdown-to-html.js",
+    "render-stream.js",
+    "safe-url.js"
+  ]
+}


### PR DESCRIPTION
A streaming Markdown-to-HTML parser for browsers, published to npm as [`streaming-markdown-html`](https://www.npmjs.com/package/streaming-markdown-html).

It emits only what is new as Markdown arrives, so a page grows a token at a time instead of being re-rendered on every chunk — which is what a language model's output needs.

A fork of [streaming-markdown](https://github.com/thetarnav/streaming-markdown) 0.2.15 (MIT, Damian Tarnawski), whose append-only design it builds on. Upstream is unmaintained, so eight fixes live here, each marked `FIX:` and measured against a CommonMark + GFM reference.

69 tests, run at several chunk sizes each, since a model's boundaries land mid-construct.